### PR TITLE
Fix Vercel deploy: remove DB dependency from build

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,5 @@
-# Supabase PostgreSQL (pooled connection)
-DATABASE_URL="postgresql://postgres.[PROJECT-REF]:[PASSWORD]@aws-0-[REGION].pooler.supabase.com:6543/postgres?pgbouncer=true"
-
-# Supabase PostgreSQL (direct connection - for migrations)
-DIRECT_URL="postgresql://postgres.[PROJECT-REF]:[PASSWORD]@aws-0-[REGION].pooler.supabase.com:5432/postgres"
+# Supabase PostgreSQL (transaction pooler - IPv4 compatible)
+DATABASE_URL="postgresql://postgres.PROJECT-REF:PASSWORD@aws-1-eu-west-3.pooler.supabase.com:6543/postgres"
 
 # OpenAI
 OPENAI_API_KEY="sk-..."

--- a/app/api/setup/route.ts
+++ b/app/api/setup/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { exec } from "child_process";
+import { promisify } from "util";
+
+const execAsync = promisify(exec);
+
+const agents = [
+  {
+    id: "valeria",
+    name: "Valeria",
+    shortBio: "Sharp, provocative, composed, and hard to impress.",
+    archetype: "dominant_teasing",
+    voiceStyle: "precise, controlled, provocative",
+  },
+  {
+    id: "luna",
+    name: "Luna",
+    shortBio: "Warm, gentle, and emotionally intuitive. She makes you feel seen.",
+    archetype: "soft_affectionate",
+    voiceStyle: "warm, gentle, expressive",
+  },
+  {
+    id: "mira",
+    name: "Mira",
+    shortBio: "Thoughtful, sharp-witted, and quietly intense. She values depth over noise.",
+    archetype: "reserved_intellectual",
+    voiceStyle: "measured, articulate, occasionally dry",
+  },
+  {
+    id: "sable",
+    name: "Sable",
+    shortBio: "Cryptic, alluring, and unpredictable. She reveals herself in fragments.",
+    archetype: "mysterious_enigmatic",
+    voiceStyle: "poetic, sparse, layered with subtext",
+  },
+  {
+    id: "kira",
+    name: "Kira",
+    shortBio: "Spontaneous, bold, and infectiously energetic. Never a dull moment.",
+    archetype: "playful_chaotic",
+    voiceStyle: "casual, energetic, unpredictable, expressive",
+  },
+];
+
+export async function POST() {
+  const results: string[] = [];
+
+  // Step 1: Run migrations
+  try {
+    const { stdout, stderr } = await execAsync("npx prisma migrate deploy");
+    results.push(`Migrations: OK - ${stdout.trim()}`);
+    if (stderr) results.push(`Migration warnings: ${stderr.trim()}`);
+  } catch (error) {
+    results.push(`Migrations error: ${String(error)}`);
+    return NextResponse.json({ success: false, results }, { status: 500 });
+  }
+
+  // Step 2: Seed agents
+  try {
+    const user = await prisma.user.upsert({
+      where: { username: "test-user" },
+      update: {},
+      create: { username: "test-user" },
+    });
+    results.push(`Test user: ${user.id}`);
+
+    for (const agent of agents) {
+      await prisma.agent.upsert({
+        where: { id: agent.id },
+        update: { name: agent.name, shortBio: agent.shortBio, archetype: agent.archetype, voiceStyle: agent.voiceStyle, config: agent },
+        create: { ...agent, config: agent },
+      });
+      results.push(`Agent seeded: ${agent.name}`);
+    }
+  } catch (error) {
+    results.push(`Seed error: ${String(error)}`);
+    return NextResponse.json({ success: false, results }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true, results });
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "prisma generate && prisma migrate deploy && next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
     "postinstall": "prisma generate",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,9 +3,8 @@ generator client {
 }
 
 datasource db {
-  provider  = "postgresql"
-  url       = env("DATABASE_URL")
-  directUrl = env("DIRECT_URL")
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
 }
 
 model User {


### PR DESCRIPTION
## Summary

- **Build was failing** because `prisma migrate deploy` tried to reach Supabase direct connection (port 5432) which is IPv6 only — Vercel uses IPv4
- Removed `prisma migrate deploy` from build command
- Removed `directUrl` from Prisma schema (not needed with pooler)
- Added `POST /api/setup` endpoint that runs migrations + seeds agents at runtime
- Simplified to only 2 env vars needed: `DATABASE_URL` and `OPENAI_API_KEY`

## After merge

1. Remove `DIRECT_URL` from Vercel env vars (no longer needed)
2. Redeploy
3. Call `POST /api/setup` once to create tables and seed agents

https://claude.ai/code/session_01Ma4QyJ8iqoqXtuhgUNY1Z4