### PR TITLE
Fix: add vercel.json for Next.js framework detection

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "framework": "nextjs"
+}


### PR DESCRIPTION
## Summary

- Vercel wasn't detecting the project as Next.js, looking for a `public` output directory instead of `.next`
- Added `vercel.json` with `"framework": "nextjs"` to fix detection

## One-line fix

https://claude.ai/code/session_01Ma4QyJ8iqoqXtuhgUNY1Z4