### PR TITLE
Allow GET on /api/setup for browser access

### DIFF
--- a/app/api/setup/route.ts
+++ b/app/api/setup/route.ts
@@ -43,7 +43,15 @@ const agents = [
   },
 ];
 
+export async function GET() {
+  return handleSetup();
+}
+
 export async function POST() {
+  return handleSetup();
+}
+
+async function handleSetup() {
   const results: string[] = [];
 
   // Step 1: Run migrations


### PR DESCRIPTION
Allow GET on /api/setup so it can be triggered directly from the browser URL bar.

https://claude.ai/code/session_01Ma4QyJ8iqoqXtuhgUNY1Z4