### PR TITLE
Fix setup: individual SQL statements for PgBouncer

### DIFF
--- a/app/api/setup/route.ts
+++ b/app/api/setup/route.ts
@@ -1,124 +1,29 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 
-const migrationSQL = `
-CREATE TABLE IF NOT EXISTS "User" (
-    "id" TEXT NOT NULL,
-    "username" TEXT NOT NULL,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
-);
-
-CREATE TABLE IF NOT EXISTS "Agent" (
-    "id" TEXT NOT NULL,
-    "name" TEXT NOT NULL,
-    "shortBio" TEXT NOT NULL,
-    "archetype" TEXT NOT NULL,
-    "voiceStyle" TEXT NOT NULL,
-    "config" JSONB NOT NULL,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT "Agent_pkey" PRIMARY KEY ("id")
-);
-
-CREATE TABLE IF NOT EXISTS "Conversation" (
-    "id" TEXT NOT NULL,
-    "userId" TEXT NOT NULL,
-    "agentId" TEXT NOT NULL,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" TIMESTAMP(3) NOT NULL,
-    CONSTRAINT "Conversation_pkey" PRIMARY KEY ("id")
-);
-
-CREATE TABLE IF NOT EXISTS "Message" (
-    "id" TEXT NOT NULL,
-    "conversationId" TEXT NOT NULL,
-    "senderRole" TEXT NOT NULL,
-    "content" TEXT NOT NULL,
-    "toneClassification" TEXT,
-    "responseMetadata" JSONB,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT "Message_pkey" PRIMARY KEY ("id")
-);
-
-CREATE TABLE IF NOT EXISTS "RelationshipState" (
-    "id" TEXT NOT NULL,
-    "userId" TEXT NOT NULL,
-    "agentId" TEXT NOT NULL,
-    "interest" INTEGER NOT NULL DEFAULT 30,
-    "trust" INTEGER NOT NULL DEFAULT 20,
-    "comfort" INTEGER NOT NULL DEFAULT 20,
-    "tension" INTEGER NOT NULL DEFAULT 30,
-    "respect" INTEGER NOT NULL DEFAULT 30,
-    "attachment" INTEGER NOT NULL DEFAULT 10,
-    "emotionalOpenness" INTEGER NOT NULL DEFAULT 15,
-    "conversationDepth" INTEGER NOT NULL DEFAULT 10,
-    "initiativeBalance" TEXT NOT NULL DEFAULT 'user_leads',
-    "dynamicAlignment" INTEGER NOT NULL DEFAULT 30,
-    "stage" INTEGER NOT NULL DEFAULT 0,
-    "currentMood" TEXT NOT NULL DEFAULT 'receptive',
-    "lastInteractionAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT "RelationshipState_pkey" PRIMARY KEY ("id")
-);
-
-CREATE TABLE IF NOT EXISTS "Memory" (
-    "id" TEXT NOT NULL,
-    "userId" TEXT NOT NULL,
-    "agentId" TEXT NOT NULL,
-    "type" TEXT NOT NULL,
-    "content" TEXT NOT NULL,
-    "salience" DOUBLE PRECISION NOT NULL,
-    "confidence" DOUBLE PRECISION NOT NULL,
-    "emotionalWeight" DOUBLE PRECISION NOT NULL,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT "Memory_pkey" PRIMARY KEY ("id")
-);
-
-CREATE TABLE IF NOT EXISTS "Milestone" (
-    "id" TEXT NOT NULL,
-    "userId" TEXT NOT NULL,
-    "agentId" TEXT NOT NULL,
-    "type" TEXT NOT NULL,
-    "label" TEXT NOT NULL,
-    "detail" TEXT,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT "Milestone_pkey" PRIMARY KEY ("id")
-);
-
-CREATE UNIQUE INDEX IF NOT EXISTS "User_username_key" ON "User"("username");
-CREATE UNIQUE INDEX IF NOT EXISTS "Conversation_userId_agentId_key" ON "Conversation"("userId", "agentId");
-CREATE INDEX IF NOT EXISTS "Message_conversationId_createdAt_idx" ON "Message"("conversationId", "createdAt");
-CREATE UNIQUE INDEX IF NOT EXISTS "RelationshipState_userId_agentId_key" ON "RelationshipState"("userId", "agentId");
-CREATE INDEX IF NOT EXISTS "Memory_userId_agentId_type_idx" ON "Memory"("userId", "agentId", "type");
-CREATE INDEX IF NOT EXISTS "Milestone_userId_agentId_idx" ON "Milestone"("userId", "agentId");
-
-DO $$ BEGIN
-  ALTER TABLE "Conversation" ADD CONSTRAINT "Conversation_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-EXCEPTION WHEN duplicate_object THEN NULL; END $$;
-
-DO $$ BEGIN
-  ALTER TABLE "Conversation" ADD CONSTRAINT "Conversation_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-EXCEPTION WHEN duplicate_object THEN NULL; END $$;
-
-DO $$ BEGIN
-  ALTER TABLE "Message" ADD CONSTRAINT "Message_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "Conversation"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-EXCEPTION WHEN duplicate_object THEN NULL; END $$;
-
-DO $$ BEGIN
-  ALTER TABLE "RelationshipState" ADD CONSTRAINT "RelationshipState_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-EXCEPTION WHEN duplicate_object THEN NULL; END $$;
-
-DO $$ BEGIN
-  ALTER TABLE "RelationshipState" ADD CONSTRAINT "RelationshipState_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-EXCEPTION WHEN duplicate_object THEN NULL; END $$;
-
-DO $$ BEGIN
-  ALTER TABLE "Memory" ADD CONSTRAINT "Memory_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-EXCEPTION WHEN duplicate_object THEN NULL; END $$;
-
-DO $$ BEGIN
-  ALTER TABLE "Memory" ADD CONSTRAINT "Memory_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-EXCEPTION WHEN duplicate_object THEN NULL; END $$;
-`;
+// Each statement runs individually (PgBouncer doesn't support multi-statement queries)
+const statements = [
+  `CREATE TABLE IF NOT EXISTS "User" ("id" TEXT NOT NULL, "username" TEXT NOT NULL, "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP, CONSTRAINT "User_pkey" PRIMARY KEY ("id"))`,
+  `CREATE TABLE IF NOT EXISTS "Agent" ("id" TEXT NOT NULL, "name" TEXT NOT NULL, "shortBio" TEXT NOT NULL, "archetype" TEXT NOT NULL, "voiceStyle" TEXT NOT NULL, "config" JSONB NOT NULL, "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP, CONSTRAINT "Agent_pkey" PRIMARY KEY ("id"))`,
+  `CREATE TABLE IF NOT EXISTS "Conversation" ("id" TEXT NOT NULL, "userId" TEXT NOT NULL, "agentId" TEXT NOT NULL, "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP, "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP, CONSTRAINT "Conversation_pkey" PRIMARY KEY ("id"))`,
+  `CREATE TABLE IF NOT EXISTS "Message" ("id" TEXT NOT NULL, "conversationId" TEXT NOT NULL, "senderRole" TEXT NOT NULL, "content" TEXT NOT NULL, "toneClassification" TEXT, "responseMetadata" JSONB, "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP, CONSTRAINT "Message_pkey" PRIMARY KEY ("id"))`,
+  `CREATE TABLE IF NOT EXISTS "RelationshipState" ("id" TEXT NOT NULL, "userId" TEXT NOT NULL, "agentId" TEXT NOT NULL, "interest" INTEGER NOT NULL DEFAULT 30, "trust" INTEGER NOT NULL DEFAULT 20, "comfort" INTEGER NOT NULL DEFAULT 20, "tension" INTEGER NOT NULL DEFAULT 30, "respect" INTEGER NOT NULL DEFAULT 30, "attachment" INTEGER NOT NULL DEFAULT 10, "emotionalOpenness" INTEGER NOT NULL DEFAULT 15, "conversationDepth" INTEGER NOT NULL DEFAULT 10, "initiativeBalance" TEXT NOT NULL DEFAULT 'user_leads', "dynamicAlignment" INTEGER NOT NULL DEFAULT 30, "stage" INTEGER NOT NULL DEFAULT 0, "currentMood" TEXT NOT NULL DEFAULT 'receptive', "lastInteractionAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP, CONSTRAINT "RelationshipState_pkey" PRIMARY KEY ("id"))`,
+  `CREATE TABLE IF NOT EXISTS "Memory" ("id" TEXT NOT NULL, "userId" TEXT NOT NULL, "agentId" TEXT NOT NULL, "type" TEXT NOT NULL, "content" TEXT NOT NULL, "salience" DOUBLE PRECISION NOT NULL, "confidence" DOUBLE PRECISION NOT NULL, "emotionalWeight" DOUBLE PRECISION NOT NULL, "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP, CONSTRAINT "Memory_pkey" PRIMARY KEY ("id"))`,
+  `CREATE TABLE IF NOT EXISTS "Milestone" ("id" TEXT NOT NULL, "userId" TEXT NOT NULL, "agentId" TEXT NOT NULL, "type" TEXT NOT NULL, "label" TEXT NOT NULL, "detail" TEXT, "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP, CONSTRAINT "Milestone_pkey" PRIMARY KEY ("id"))`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS "User_username_key" ON "User"("username")`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS "Conversation_userId_agentId_key" ON "Conversation"("userId", "agentId")`,
+  `CREATE INDEX IF NOT EXISTS "Message_conversationId_createdAt_idx" ON "Message"("conversationId", "createdAt")`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS "RelationshipState_userId_agentId_key" ON "RelationshipState"("userId", "agentId")`,
+  `CREATE INDEX IF NOT EXISTS "Memory_userId_agentId_type_idx" ON "Memory"("userId", "agentId", "type")`,
+  `CREATE INDEX IF NOT EXISTS "Milestone_userId_agentId_idx" ON "Milestone"("userId", "agentId")`,
+  `DO $$ BEGIN ALTER TABLE "Conversation" ADD CONSTRAINT "Conversation_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE; EXCEPTION WHEN duplicate_object THEN NULL; END $$`,
+  `DO $$ BEGIN ALTER TABLE "Conversation" ADD CONSTRAINT "Conversation_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent"("id") ON DELETE RESTRICT ON UPDATE CASCADE; EXCEPTION WHEN duplicate_object THEN NULL; END $$`,
+  `DO $$ BEGIN ALTER TABLE "Message" ADD CONSTRAINT "Message_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "Conversation"("id") ON DELETE RESTRICT ON UPDATE CASCADE; EXCEPTION WHEN duplicate_object THEN NULL; END $$`,
+  `DO $$ BEGIN ALTER TABLE "RelationshipState" ADD CONSTRAINT "RelationshipState_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE; EXCEPTION WHEN duplicate_object THEN NULL; END $$`,
+  `DO $$ BEGIN ALTER TABLE "RelationshipState" ADD CONSTRAINT "RelationshipState_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent"("id") ON DELETE RESTRICT ON UPDATE CASCADE; EXCEPTION WHEN duplicate_object THEN NULL; END $$`,
+  `DO $$ BEGIN ALTER TABLE "Memory" ADD CONSTRAINT "Memory_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE; EXCEPTION WHEN duplicate_object THEN NULL; END $$`,
+  `DO $$ BEGIN ALTER TABLE "Memory" ADD CONSTRAINT "Memory_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent"("id") ON DELETE RESTRICT ON UPDATE CASCADE; EXCEPTION WHEN duplicate_object THEN NULL; END $$`,
+];
 
 const agents = [
   { id: "valeria", name: "Valeria", shortBio: "Sharp, provocative, composed, and hard to impress.", archetype: "dominant_teasing", voiceStyle: "precise, controlled, provocative" },
@@ -131,16 +36,18 @@ const agents = [
 async function handleSetup() {
   const results: string[] = [];
 
-  // Step 1: Run migration SQL directly
+  // Step 1: Run each SQL statement one at a time (PgBouncer requirement)
   try {
-    await prisma.$executeRawUnsafe(migrationSQL);
-    results.push("Tables created successfully");
+    for (let i = 0; i < statements.length; i++) {
+      await prisma.$executeRawUnsafe(statements[i]);
+    }
+    results.push("All tables, indexes, and foreign keys created");
   } catch (error) {
     results.push(`Migration error: ${String(error)}`);
     return NextResponse.json({ success: false, results }, { status: 500 });
   }
 
-  // Step 2: Seed agents
+  // Step 2: Seed data
   try {
     const user = await prisma.user.upsert({
       where: { username: "test-user" },


### PR DESCRIPTION
## Summary

PgBouncer (Supabase transaction pooler) doesn't allow multiple SQL statements in a single prepared statement. Changed `/api/setup` to execute each CREATE TABLE, CREATE INDEX, and ALTER TABLE as individual calls.

## After merge + deploy

Open: `https://your-app.vercel.app/api/setup`

Should return `{"success": true, ...}` with all tables created and agents seeded.

https://claude.ai/code/session_01Ma4QyJ8iqoqXtuhgUNY1Z4