### PR TITLE
Proper Supabase + Prisma + Vercel config (definitive fix)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,10 @@
-# Supabase PostgreSQL (transaction pooler - IPv4 compatible)
-DATABASE_URL="postgresql://postgres.PROJECT-REF:PASSWORD@aws-1-eu-west-3.pooler.supabase.com:6543/postgres"
+# Supabase Transaction Pooler (port 6543) - for app runtime queries
+# pgbouncer=true disables prepared statements (required for Supavisor transaction mode)
+# connection_limit=1 prevents serverless functions from exhausting the pool
+DATABASE_URL="postgresql://postgres.PROJECT-REF:PASSWORD@aws-1-eu-west-3.pooler.supabase.com:6543/postgres?pgbouncer=true&connection_limit=1"
+
+# Supabase Session Pooler (port 5432) - for migrations (supports prepared statements, IPv4 compatible)
+DIRECT_URL="postgresql://postgres.PROJECT-REF:PASSWORD@aws-1-eu-west-3.pooler.supabase.com:5432/postgres"
 
 # OpenAI
 OPENAI_API_KEY="sk-..."

--- a/app/api/setup/route.ts
+++ b/app/api/setup/route.ts
@@ -1,125 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 
-const migrationSQL = `
-CREATE TABLE IF NOT EXISTS "User" (
-    "id" TEXT NOT NULL,
-    "username" TEXT NOT NULL,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
-);
-
-CREATE TABLE IF NOT EXISTS "Agent" (
-    "id" TEXT NOT NULL,
-    "name" TEXT NOT NULL,
-    "shortBio" TEXT NOT NULL,
-    "archetype" TEXT NOT NULL,
-    "voiceStyle" TEXT NOT NULL,
-    "config" JSONB NOT NULL,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT "Agent_pkey" PRIMARY KEY ("id")
-);
-
-CREATE TABLE IF NOT EXISTS "Conversation" (
-    "id" TEXT NOT NULL,
-    "userId" TEXT NOT NULL,
-    "agentId" TEXT NOT NULL,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" TIMESTAMP(3) NOT NULL,
-    CONSTRAINT "Conversation_pkey" PRIMARY KEY ("id")
-);
-
-CREATE TABLE IF NOT EXISTS "Message" (
-    "id" TEXT NOT NULL,
-    "conversationId" TEXT NOT NULL,
-    "senderRole" TEXT NOT NULL,
-    "content" TEXT NOT NULL,
-    "toneClassification" TEXT,
-    "responseMetadata" JSONB,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT "Message_pkey" PRIMARY KEY ("id")
-);
-
-CREATE TABLE IF NOT EXISTS "RelationshipState" (
-    "id" TEXT NOT NULL,
-    "userId" TEXT NOT NULL,
-    "agentId" TEXT NOT NULL,
-    "interest" INTEGER NOT NULL DEFAULT 30,
-    "trust" INTEGER NOT NULL DEFAULT 20,
-    "comfort" INTEGER NOT NULL DEFAULT 20,
-    "tension" INTEGER NOT NULL DEFAULT 30,
-    "respect" INTEGER NOT NULL DEFAULT 30,
-    "attachment" INTEGER NOT NULL DEFAULT 10,
-    "emotionalOpenness" INTEGER NOT NULL DEFAULT 15,
-    "conversationDepth" INTEGER NOT NULL DEFAULT 10,
-    "initiativeBalance" TEXT NOT NULL DEFAULT 'user_leads',
-    "dynamicAlignment" INTEGER NOT NULL DEFAULT 30,
-    "stage" INTEGER NOT NULL DEFAULT 0,
-    "currentMood" TEXT NOT NULL DEFAULT 'receptive',
-    "lastInteractionAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT "RelationshipState_pkey" PRIMARY KEY ("id")
-);
-
-CREATE TABLE IF NOT EXISTS "Memory" (
-    "id" TEXT NOT NULL,
-    "userId" TEXT NOT NULL,
-    "agentId" TEXT NOT NULL,
-    "type" TEXT NOT NULL,
-    "content" TEXT NOT NULL,
-    "salience" DOUBLE PRECISION NOT NULL,
-    "confidence" DOUBLE PRECISION NOT NULL,
-    "emotionalWeight" DOUBLE PRECISION NOT NULL,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT "Memory_pkey" PRIMARY KEY ("id")
-);
-
-CREATE TABLE IF NOT EXISTS "Milestone" (
-    "id" TEXT NOT NULL,
-    "userId" TEXT NOT NULL,
-    "agentId" TEXT NOT NULL,
-    "type" TEXT NOT NULL,
-    "label" TEXT NOT NULL,
-    "detail" TEXT,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT "Milestone_pkey" PRIMARY KEY ("id")
-);
-
-CREATE UNIQUE INDEX IF NOT EXISTS "User_username_key" ON "User"("username");
-CREATE UNIQUE INDEX IF NOT EXISTS "Conversation_userId_agentId_key" ON "Conversation"("userId", "agentId");
-CREATE INDEX IF NOT EXISTS "Message_conversationId_createdAt_idx" ON "Message"("conversationId", "createdAt");
-CREATE UNIQUE INDEX IF NOT EXISTS "RelationshipState_userId_agentId_key" ON "RelationshipState"("userId", "agentId");
-CREATE INDEX IF NOT EXISTS "Memory_userId_agentId_type_idx" ON "Memory"("userId", "agentId", "type");
-CREATE INDEX IF NOT EXISTS "Milestone_userId_agentId_idx" ON "Milestone"("userId", "agentId");
-
-DO $$ BEGIN
-  ALTER TABLE "Conversation" ADD CONSTRAINT "Conversation_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-EXCEPTION WHEN duplicate_object THEN NULL; END $$;
-
-DO $$ BEGIN
-  ALTER TABLE "Conversation" ADD CONSTRAINT "Conversation_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-EXCEPTION WHEN duplicate_object THEN NULL; END $$;
-
-DO $$ BEGIN
-  ALTER TABLE "Message" ADD CONSTRAINT "Message_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "Conversation"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-EXCEPTION WHEN duplicate_object THEN NULL; END $$;
-
-DO $$ BEGIN
-  ALTER TABLE "RelationshipState" ADD CONSTRAINT "RelationshipState_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-EXCEPTION WHEN duplicate_object THEN NULL; END $$;
-
-DO $$ BEGIN
-  ALTER TABLE "RelationshipState" ADD CONSTRAINT "RelationshipState_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-EXCEPTION WHEN duplicate_object THEN NULL; END $$;
-
-DO $$ BEGIN
-  ALTER TABLE "Memory" ADD CONSTRAINT "Memory_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-EXCEPTION WHEN duplicate_object THEN NULL; END $$;
-
-DO $$ BEGIN
-  ALTER TABLE "Memory" ADD CONSTRAINT "Memory_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-EXCEPTION WHEN duplicate_object THEN NULL; END $$;
-`;
-
 const agents = [
   { id: "valeria", name: "Valeria", shortBio: "Sharp, provocative, composed, and hard to impress.", archetype: "dominant_teasing", voiceStyle: "precise, controlled, provocative" },
   { id: "luna", name: "Luna", shortBio: "Warm, gentle, and emotionally intuitive. She makes you feel seen.", archetype: "soft_affectionate", voiceStyle: "warm, gentle, expressive" },
@@ -131,16 +12,6 @@ const agents = [
 async function handleSetup() {
   const results: string[] = [];
 
-  // Step 1: Run migration SQL directly
-  try {
-    await prisma.$executeRawUnsafe(migrationSQL);
-    results.push("Tables created successfully");
-  } catch (error) {
-    results.push(`Migration error: ${String(error)}`);
-    return NextResponse.json({ success: false, results }, { status: 500 });
-  }
-
-  // Step 2: Seed agents
   try {
     const user = await prisma.user.upsert({
       where: { username: "test-user" },
@@ -158,7 +29,7 @@ async function handleSetup() {
       results.push(`Agent seeded: ${agent.name}`);
     }
   } catch (error) {
-    results.push(`Seed error: ${String(error)}`);
+    results.push(`Error: ${String(error)}`);
     return NextResponse.json({ success: false, results }, { status: 500 });
   }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "prisma generate && next build",
+    "build": "prisma generate && prisma migrate deploy && next build",
     "start": "next start",
     "lint": "next lint",
     "postinstall": "prisma generate",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,8 +3,9 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
 }
 
 model User {


### PR DESCRIPTION
## Summary

Definitive fix based on official Prisma + Supabase + Vercel documentation.

**The problem:** We were trying to run migrations at runtime (serverless), which doesn't work. Migrations should run at **build time**.

**The fix — 4 changes:**

1. **`prisma/schema.prisma`** — Restored `directUrl = env("DIRECT_URL")`. This tells Prisma CLI to use the session pooler (port 5432) for migrations, while the app uses the transaction pooler (port 6543) at runtime.

2. **`package.json`** — Build script is now `prisma generate && prisma migrate deploy && next build`. Migrations run during Vercel's build phase (which has CLI access and write permissions).

3. **`.env.example`** — Correct URLs documented:
   - `DATABASE_URL`: transaction pooler (6543) with `?pgbouncer=true&connection_limit=1`
   - `DIRECT_URL`: session pooler (5432) — IPv4 compatible, supports prepared statements

4. **`/api/setup`** — Simplified to seed-only (inserts test user + 5 agents). No more raw SQL — tables are created by `prisma migrate deploy`.

## Env vars needed on Vercel

| Variable | Value |
|----------|-------|
| `DATABASE_URL` | `postgresql://postgres.tluhxsncydpjkcqsmbck:%21Aa13423139@aws-1-eu-west-3.pooler.supabase.com:6543/postgres?pgbouncer=true&connection_limit=1` |
| `DIRECT_URL` | `postgresql://postgres.tluhxsncydpjkcqsmbck:%21Aa13423139@aws-1-eu-west-3.pooler.supabase.com:5432/postgres` |
| `OPENAI_API_KEY` | your key |
| `OPENAI_MODEL` | `gpt-4o` |

**Key difference:** `DIRECT_URL` now uses `pooler.supabase.com:5432` (session pooler) instead of `db.xxx.supabase.co:5432` (direct connection). Session pooler is IPv4 compatible, direct connection is IPv6 only.

## After merge

1. Update env vars on Vercel (especially add `DIRECT_URL` and update `DATABASE_URL`)
2. Vercel redeploys → migrations run at build → tables created
3. Open `/api/setup` to seed agents
4. App is ready

https://claude.ai/code/session_01Ma4QyJ8iqoqXtuhgUNY1Z4