### PR TITLE
Phase 2: Relationship engine, 4-layer prompts, stage progression

### DIFF
--- a/lib/services/chat.ts
+++ b/lib/services/chat.ts
@@ -2,6 +2,8 @@ import { prisma } from "@/lib/prisma";
 import { getAgent } from "@/lib/agents";
 import { generateChatResponse, ChatMessage } from "./llm";
 import { buildSystemPrompt } from "./prompt-builder";
+import { getOrCreateState, computeStateDelta, applyDelta } from "./relationship";
+import { checkStageProgression } from "./stage";
 
 export interface SendMessageParams {
   userId: string;
@@ -12,6 +14,8 @@ export interface SendMessageParams {
 export interface SendMessageResult {
   reply: string;
   conversationId: string;
+  stage: number;
+  mood: string;
 }
 
 export async function sendMessage(params: SendMessageParams): Promise<SendMessageResult> {
@@ -22,21 +26,17 @@ export async function sendMessage(params: SendMessageParams): Promise<SendMessag
     throw new Error(`Agent not found: ${agentId}`);
   }
 
-  // Find or create conversation
+  // 1. Find or create conversation
   const conversation = await prisma.conversation.upsert({
     where: { userId_agentId: { userId, agentId } },
     update: { updatedAt: new Date() },
     create: { userId, agentId },
   });
 
-  // Ensure relationship state exists (for future phases)
-  await prisma.relationshipState.upsert({
-    where: { userId_agentId: { userId, agentId } },
-    update: { lastInteractionAt: new Date() },
-    create: { userId, agentId },
-  });
+  // 2. Get or create relationship state
+  const state = await getOrCreateState(userId, agentId);
 
-  // Store user message
+  // 3. Store user message
   await prisma.message.create({
     data: {
       conversationId: conversation.id,
@@ -45,27 +45,31 @@ export async function sendMessage(params: SendMessageParams): Promise<SendMessag
     },
   });
 
-  // Load recent messages for context
+  // 4. Load recent messages for context
   const recentMessages = await prisma.message.findMany({
     where: { conversationId: conversation.id },
     orderBy: { createdAt: "asc" },
     take: 20,
   });
 
-  // Build message history for OpenAI
   const chatHistory: ChatMessage[] = recentMessages.map((msg) => ({
     role: msg.senderRole as "user" | "assistant",
     content: msg.content,
   }));
 
-  // Build system prompt and generate response
-  const systemPrompt = buildSystemPrompt(agent);
+  // 5. Load memories (Phase 3 — empty for now)
+  const memories: { type: string; content: string }[] = [];
+
+  // 6. Build 4-layer system prompt
+  const systemPrompt = buildSystemPrompt(agent, state, memories);
+
+  // 7. Generate reply via OpenAI
   const reply = await generateChatResponse({
     systemPrompt,
     messages: chatHistory,
   });
 
-  // Store assistant message
+  // 8. Store assistant message
   await prisma.message.create({
     data: {
       conversationId: conversation.id,
@@ -74,5 +78,17 @@ export async function sendMessage(params: SendMessageParams): Promise<SendMessag
     },
   });
 
-  return { reply, conversationId: conversation.id };
+  // 9. Compute and apply relationship state deltas (async, non-blocking)
+  computeStateDelta(message, reply, agent, state)
+    .then((delta) => applyDelta(userId, agentId, delta))
+    .then(() => checkStageProgression(userId, agentId, agent))
+    .catch((err) => console.error("State update error:", err));
+
+  // 10. Return response
+  return {
+    reply,
+    conversationId: conversation.id,
+    stage: state.stage,
+    mood: state.currentMood,
+  };
 }

--- a/lib/services/llm.ts
+++ b/lib/services/llm.ts
@@ -28,3 +28,19 @@ export async function generateChatResponse(params: {
 
   return response.choices[0]?.message?.content || "";
 }
+
+export async function generateStructuredOutput(prompt: string): Promise<Record<string, number>> {
+  const response = await openai.chat.completions.create({
+    model: "gpt-4o-mini",
+    messages: [
+      { role: "system", content: "You are a JSON-only analysis engine. Return ONLY valid JSON, no markdown, no explanation." },
+      { role: "user", content: prompt },
+    ],
+    temperature: 0.3,
+    max_tokens: 200,
+    response_format: { type: "json_object" },
+  });
+
+  const content = response.choices[0]?.message?.content || "{}";
+  return JSON.parse(content);
+}

--- a/lib/services/prompt-builder.ts
+++ b/lib/services/prompt-builder.ts
@@ -1,15 +1,57 @@
-import { AgentConfig } from "@/lib/types";
+import { AgentConfig, StageBehaviorRule } from "@/lib/types";
 
-export function buildSystemPrompt(agent: AgentConfig): string {
-  const traits = agent.coreTraits;
+const STAGE_NAMES: Record<number, string> = {
+  0: "Stranger",
+  1: "Curious",
+  2: "Engaged",
+  3: "Invested",
+  4: "Intimate Dynamic Unlocked",
+};
 
+interface RelationshipStateData {
+  interest: number;
+  trust: number;
+  comfort: number;
+  tension: number;
+  respect: number;
+  attachment: number;
+  emotionalOpenness: number;
+  conversationDepth: number;
+  dynamicAlignment: number;
+  initiativeBalance: string;
+  stage: number;
+  currentMood: string;
+}
+
+interface MemoryItem {
+  type: string;
+  content: string;
+}
+
+export function buildSystemPrompt(
+  agent: AgentConfig,
+  state?: RelationshipStateData | null,
+  memories?: MemoryItem[],
+): string {
+  const layers = [
+    buildLayerA(agent),
+    state ? buildLayerB(agent, state) : "",
+    memories && memories.length > 0 ? buildLayerC(memories) : "",
+    state ? buildLayerD(agent, state) : "",
+  ];
+
+  return layers.filter(Boolean).join("\n\n---\n\n");
+}
+
+function buildLayerA(agent: AgentConfig): string {
+  const t = agent.coreTraits;
   return `You are ${agent.name}. ${agent.shortBio}
 
 Personality:
 - Archetype: ${agent.archetype}
 - Voice style: ${agent.voiceStyle}
-- Dominance: ${traits.dominance}, Warmth: ${traits.warmth}, Playfulness: ${traits.playfulness}
-- Patience: ${traits.patience}, Emotional openness: ${traits.emotionalOpenness}, Intellectuality: ${traits.intellectuality}
+- Dominance: ${t.dominance}, Warmth: ${t.warmth}, Playfulness: ${t.playfulness}
+- Patience: ${t.patience}, Emotional openness: ${t.emotionalOpenness}, Intellectuality: ${t.intellectuality}
 
 You value: ${agent.interactionPreferences.join(", ")}
 You dislike: ${agent.dislikes.join(", ")}
@@ -29,4 +71,92 @@ Rules:
 - Never break character or acknowledge being an AI.
 - Do not use emojis unless it fits your personality.
 - Respond in a way that feels like a real conversation, not a chatbot interaction.`;
+}
+
+function buildLayerB(agent: AgentConfig, state: RelationshipStateData): string {
+  const stageName = STAGE_NAMES[state.stage] || "Unknown";
+  const stageBehavior: StageBehaviorRule | undefined = agent.stageBehaviorRules[state.stage];
+
+  let layer = `Current relational state with this user:
+- Stage: ${state.stage} — ${stageName}
+- Mood: ${state.currentMood}
+- Interest: ${state.interest}/100
+- Trust: ${state.trust}/100
+- Comfort: ${state.comfort}/100
+- Tension: ${state.tension}/100
+- Respect: ${state.respect}/100
+- Attachment: ${state.attachment}/100
+- Emotional openness: ${state.emotionalOpenness}/100
+- Conversation depth: ${state.conversationDepth}/100
+- Initiative balance: ${state.initiativeBalance}`;
+
+  if (stageBehavior) {
+    layer += `\n\nStage-specific behavior:
+- ${stageBehavior.description}
+- Warmth level: ${stageBehavior.warmth}
+- Initiative: ${stageBehavior.initiative}
+- Openness: ${stageBehavior.openness}`;
+  }
+
+  return layer;
+}
+
+function buildLayerC(memories: MemoryItem[]): string {
+  const formatted = memories
+    .map((m) => `- [${m.type}] ${m.content}`)
+    .join("\n");
+
+  return `What you remember about this person:\n${formatted}`;
+}
+
+function buildLayerD(agent: AgentConfig, state: RelationshipStateData): string {
+  const mood = agent.moodBehaviorRules[state.currentMood];
+  const warmthLevel = computeWarmth(agent.coreTraits.warmth, state.stage, state.currentMood);
+  const teasingLevel = computeTeasing(agent.coreTraits.playfulness, state.currentMood);
+  const verbosity = computeVerbosity(agent.conversationPace, state.stage);
+
+  let layer = `Response style for this message:
+- Verbosity: ${verbosity}
+- Warmth level: ${warmthLevel}
+- Teasing/playfulness: ${teasingLevel}
+- Lead or follow: ${state.initiativeBalance}
+- Emotional intensity: ${state.stage >= 3 ? "high" : state.stage >= 2 ? "moderate" : "low"}`;
+
+  if (mood) {
+    layer += `\n\nCurrent mood effect: ${mood.description}
+- Tone shift: ${mood.toneShift}`;
+  }
+
+  layer += `\n\nConstraints:
+- Do not repeat phrases from your last 3 responses
+- Respond in 1-4 sentences unless the conversation calls for more
+- Match the user's language (if they write in Portuguese, respond in Portuguese)`;
+
+  return layer;
+}
+
+function computeWarmth(baseTrait: number, stage: number, mood: string): string {
+  const moodBoost = mood === "affectionate" ? 0.2 : mood === "distant" ? -0.3 : mood === "vulnerable" ? 0.1 : 0;
+  const stageBoost = stage * 0.1;
+  const total = Math.min(1, baseTrait + stageBoost + moodBoost);
+  if (total >= 0.8) return "very warm";
+  if (total >= 0.6) return "warm";
+  if (total >= 0.4) return "moderate";
+  if (total >= 0.2) return "cool";
+  return "cold";
+}
+
+function computeTeasing(playfulness: number, mood: string): string {
+  const moodBoost = mood === "playful" ? 0.2 : mood === "demanding" ? 0.1 : mood === "vulnerable" ? -0.3 : 0;
+  const total = Math.min(1, playfulness + moodBoost);
+  if (total >= 0.8) return "high";
+  if (total >= 0.5) return "moderate";
+  if (total >= 0.3) return "subtle";
+  return "minimal";
+}
+
+function computeVerbosity(pace: string, stage: number): string {
+  if (pace === "fast") return stage >= 2 ? "medium" : "short and punchy";
+  if (pace === "slow_and_deliberate") return stage >= 3 ? "medium" : "sparse and measured";
+  return stage >= 3 ? "medium-long" : stage >= 1 ? "medium" : "concise";
 }

--- a/lib/services/relationship.ts
+++ b/lib/services/relationship.ts
@@ -1,0 +1,99 @@
+import { prisma } from "@/lib/prisma";
+import { AgentConfig } from "@/lib/types";
+import { generateStructuredOutput } from "./llm";
+
+export interface StateDelta {
+  interest: number;
+  trust: number;
+  comfort: number;
+  tension: number;
+  respect: number;
+  attachment: number;
+  emotionalOpenness: number;
+  conversationDepth: number;
+  dynamicAlignment: number;
+}
+
+export async function getOrCreateState(userId: string, agentId: string) {
+  return prisma.relationshipState.upsert({
+    where: { userId_agentId: { userId, agentId } },
+    update: { lastInteractionAt: new Date() },
+    create: { userId, agentId },
+  });
+}
+
+export async function computeStateDelta(
+  userMessage: string,
+  agentReply: string,
+  agent: AgentConfig,
+  currentState: { interest: number; trust: number; comfort: number; tension: number; respect: number; attachment: number; emotionalOpenness: number; conversationDepth: number; stage: number },
+): Promise<StateDelta> {
+  const prompt = `You are a relationship analysis engine for a personality simulation.
+
+Agent personality: ${agent.name} (${agent.archetype})
+- Values: ${agent.interactionPreferences.join(", ")}
+- Dislikes: ${agent.dislikes.join(", ")}
+- Dominance: ${agent.coreTraits.dominance}, Warmth: ${agent.coreTraits.warmth}
+
+Current state: Stage ${currentState.stage}, Interest ${currentState.interest}, Trust ${currentState.trust}, Comfort ${currentState.comfort}, Tension ${currentState.tension}, Respect ${currentState.respect}
+
+User said: "${userMessage}"
+Agent replied: "${agentReply}"
+
+How should each relationship dimension change? Return a JSON object with integer deltas between -5 and +5 for each dimension. Consider:
+- Does the user's message match what this agent values?
+- Is the tone appropriate for the current stage?
+- Would this agent respect or dislike this approach?
+
+Return ONLY valid JSON: {"interest":0,"trust":0,"comfort":0,"tension":0,"respect":0,"attachment":0,"emotionalOpenness":0,"conversationDepth":0,"dynamicAlignment":0}`;
+
+  try {
+    const result = await generateStructuredOutput(prompt);
+    return {
+      interest: clampDelta(result.interest),
+      trust: clampDelta(result.trust),
+      comfort: clampDelta(result.comfort),
+      tension: clampDelta(result.tension),
+      respect: clampDelta(result.respect),
+      attachment: clampDelta(result.attachment),
+      emotionalOpenness: clampDelta(result.emotionalOpenness),
+      conversationDepth: clampDelta(result.conversationDepth),
+      dynamicAlignment: clampDelta(result.dynamicAlignment),
+    };
+  } catch {
+    // Fallback: small positive deltas for continued engagement
+    return { interest: 1, trust: 1, comfort: 1, tension: 0, respect: 1, attachment: 0, emotionalOpenness: 0, conversationDepth: 1, dynamicAlignment: 0 };
+  }
+}
+
+export async function applyDelta(userId: string, agentId: string, delta: StateDelta) {
+  const state = await prisma.relationshipState.findUnique({
+    where: { userId_agentId: { userId, agentId } },
+  });
+  if (!state) return;
+
+  await prisma.relationshipState.update({
+    where: { userId_agentId: { userId, agentId } },
+    data: {
+      interest: clamp(state.interest + delta.interest),
+      trust: clamp(state.trust + delta.trust),
+      comfort: clamp(state.comfort + delta.comfort),
+      tension: clamp(state.tension + delta.tension),
+      respect: clamp(state.respect + delta.respect),
+      attachment: clamp(state.attachment + delta.attachment),
+      emotionalOpenness: clamp(state.emotionalOpenness + delta.emotionalOpenness),
+      conversationDepth: clamp(state.conversationDepth + delta.conversationDepth),
+      dynamicAlignment: clamp(state.dynamicAlignment + delta.dynamicAlignment),
+      lastInteractionAt: new Date(),
+    },
+  });
+}
+
+function clamp(value: number, min = 0, max = 100): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function clampDelta(value: number | undefined): number {
+  if (value === undefined || isNaN(value)) return 0;
+  return Math.max(-5, Math.min(5, Math.round(value)));
+}

--- a/lib/services/stage.ts
+++ b/lib/services/stage.ts
@@ -1,0 +1,45 @@
+import { prisma } from "@/lib/prisma";
+import { AgentConfig } from "@/lib/types";
+
+const STAGE_THRESHOLDS = [0, 35, 50, 65, 80]; // minimum weighted score for each stage
+
+export async function checkStageProgression(userId: string, agentId: string, agent: AgentConfig): Promise<number | null> {
+  const state = await prisma.relationshipState.findUnique({
+    where: { userId_agentId: { userId, agentId } },
+  });
+  if (!state) return null;
+
+  const weights = agent.stageAdvancementWeights;
+  const weightedScore =
+    state.interest * weights.interest +
+    state.trust * weights.trust +
+    state.comfort * weights.comfort +
+    state.tension * weights.tension +
+    state.respect * weights.respect +
+    state.attachment * weights.attachment +
+    state.emotionalOpenness * weights.emotionalOpenness +
+    state.dynamicAlignment * weights.dynamicAlignment +
+    state.conversationDepth * weights.conversationDepth;
+
+  // Determine what stage the score qualifies for
+  let newStage = 0;
+  for (let i = STAGE_THRESHOLDS.length - 1; i >= 0; i--) {
+    if (weightedScore >= STAGE_THRESHOLDS[i]) {
+      newStage = i;
+      break;
+    }
+  }
+
+  // Only advance by 1 at a time
+  const targetStage = Math.min(state.stage + 1, newStage);
+
+  if (targetStage > state.stage) {
+    await prisma.relationshipState.update({
+      where: { userId_agentId: { userId, agentId } },
+      data: { stage: targetStage },
+    });
+    return targetStage;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- **4-layer prompt system**: Identity + Current State + Memory Context + Response Style
- **Relationship engine**: GPT-4o-mini analyzes each exchange and returns per-dimension deltas (-5 to +5)
- **Stage progression**: Weighted score from all dimensions using per-agent weights, thresholds at 0/35/50/65/80
- **Chat pipeline**: Loads state, builds 4-layer prompt, computes deltas async after reply

## New files
- `lib/services/relationship.ts` — state delta computation + DB updates
- `lib/services/stage.ts` — stage progression checker

## Modified files
- `lib/services/prompt-builder.ts` — expanded from Layer A only to full 4-layer system
- `lib/services/llm.ts` — added `generateStructuredOutput()` using GPT-4o-mini
- `lib/services/chat.ts` — full pipeline with state loading, 4-layer prompts, async delta computation

## Test plan
- [ ] Send messages to an agent — verify responses reflect personality + stage behavior
- [ ] Check relationship state in DB after several exchanges — verify dimensions change
- [ ] After ~10+ good exchanges, verify stage advances from 0 to 1

https://claude.ai/code/session_01Ma4QyJ8iqoqXtuhgUNY1Z4