### PR TITLE
Phase 3: Memory system + mood engine

### DIFF
--- a/lib/services/chat.ts
+++ b/lib/services/chat.ts
@@ -4,6 +4,8 @@ import { generateChatResponse, ChatMessage } from "./llm";
 import { buildSystemPrompt } from "./prompt-builder";
 import { getOrCreateState, computeStateDelta, applyDelta } from "./relationship";
 import { checkStageProgression } from "./stage";
+import { retrieveMemories, extractMemories } from "./memory";
+import { updateMood } from "./mood";
 
 export interface SendMessageParams {
   userId: string;
@@ -33,8 +35,9 @@ export async function sendMessage(params: SendMessageParams): Promise<SendMessag
     create: { userId, agentId },
   });
 
-  // 2. Get or create relationship state
+  // 2. Get relationship state + update mood
   const state = await getOrCreateState(userId, agentId);
+  const mood = await updateMood(userId, agentId, agent);
 
   // 3. Store user message
   await prisma.message.create({
@@ -45,31 +48,32 @@ export async function sendMessage(params: SendMessageParams): Promise<SendMessag
     },
   });
 
-  // 4. Load recent messages for context
-  const recentMessages = await prisma.message.findMany({
-    where: { conversationId: conversation.id },
-    orderBy: { createdAt: "asc" },
-    take: 20,
-  });
+  // 4. Load context in parallel: recent messages + memories
+  const [recentMessages, memories] = await Promise.all([
+    prisma.message.findMany({
+      where: { conversationId: conversation.id },
+      orderBy: { createdAt: "asc" },
+      take: 20,
+    }),
+    retrieveMemories(userId, agentId, agent),
+  ]);
 
   const chatHistory: ChatMessage[] = recentMessages.map((msg) => ({
     role: msg.senderRole as "user" | "assistant",
     content: msg.content,
   }));
 
-  // 5. Load memories (Phase 3 — empty for now)
-  const memories: { type: string; content: string }[] = [];
+  // 5. Build 4-layer system prompt with state + memories
+  const stateWithMood = { ...state, currentMood: mood };
+  const systemPrompt = buildSystemPrompt(agent, stateWithMood, memories);
 
-  // 6. Build 4-layer system prompt
-  const systemPrompt = buildSystemPrompt(agent, state, memories);
-
-  // 7. Generate reply via OpenAI
+  // 6. Generate reply via OpenAI
   const reply = await generateChatResponse({
     systemPrompt,
     messages: chatHistory,
   });
 
-  // 8. Store assistant message
+  // 7. Store assistant message
   await prisma.message.create({
     data: {
       conversationId: conversation.id,
@@ -78,17 +82,24 @@ export async function sendMessage(params: SendMessageParams): Promise<SendMessag
     },
   });
 
-  // 9. Compute and apply relationship state deltas (async, non-blocking)
-  computeStateDelta(message, reply, agent, state)
-    .then((delta) => applyDelta(userId, agentId, delta))
-    .then(() => checkStageProgression(userId, agentId, agent))
-    .catch((err) => console.error("State update error:", err));
+  // 8. Background tasks: state deltas, stage check, memory extraction
+  const messageCount = recentMessages.length;
+  const allMessages = [...recentMessages.map((m) => ({ senderRole: m.senderRole, content: m.content })), { senderRole: "assistant", content: reply }];
 
-  // 10. Return response
+  Promise.all([
+    // Compute and apply relationship state deltas
+    computeStateDelta(message, reply, agent, state)
+      .then((delta) => applyDelta(userId, agentId, delta))
+      .then(() => checkStageProgression(userId, agentId, agent)),
+    // Extract memories every 3 turns
+    messageCount % 6 === 0 ? extractMemories(userId, agentId, allMessages, agent) : Promise.resolve(0),
+  ]).catch((err) => console.error("Background task error:", err));
+
+  // 9. Return response
   return {
     reply,
     conversationId: conversation.id,
     stage: state.stage,
-    mood: state.currentMood,
+    mood,
   };
 }

--- a/lib/services/memory.ts
+++ b/lib/services/memory.ts
@@ -1,0 +1,132 @@
+import { prisma } from "@/lib/prisma";
+import { AgentConfig } from "@/lib/types";
+import { generateStructuredOutput } from "./llm";
+
+interface MemoryCandidate {
+  content: string;
+  type: string;
+  salience: number;
+  confidence: number;
+  emotionalWeight: number;
+}
+
+const VALID_TYPES = ["fact", "preference", "boundary", "milestone", "inside_joke", "relational_pattern", "conflict", "repair"];
+
+/**
+ * Extract memories from recent messages using GPT-4o-mini.
+ * Called every ~3 turns or when exchange seems significant.
+ */
+export async function extractMemories(
+  userId: string,
+  agentId: string,
+  recentMessages: { senderRole: string; content: string }[],
+  agent: AgentConfig,
+): Promise<number> {
+  const last6 = recentMessages.slice(-6);
+  if (last6.length < 2) return 0;
+
+  const conversation = last6
+    .map((m) => `${m.senderRole === "user" ? "User" : agent.name}: ${m.content}`)
+    .join("\n");
+
+  const prompt = `Analyze this conversation and extract any memorable information about the user.
+
+Agent personality: ${agent.name} (${agent.archetype})
+Memory preferences: ${agent.memoryBias.join(", ")}
+
+Conversation:
+${conversation}
+
+Extract memories as a JSON object with a "memories" array. Each memory should have:
+- "content": what to remember (1 sentence)
+- "type": one of [fact, preference, boundary, milestone, inside_joke, relational_pattern, conflict, repair]
+- "salience": importance 0.0-1.0
+- "confidence": how sure 0.0-1.0
+- "emotionalWeight": emotional significance 0.0-1.0
+
+Only extract genuinely memorable things. If nothing notable, return {"memories":[]}.
+Return ONLY valid JSON.`;
+
+  try {
+    const result = await generateStructuredOutput(prompt);
+    const candidates: MemoryCandidate[] = (result.memories as unknown as MemoryCandidate[]) || [];
+    let stored = 0;
+
+    for (const mem of candidates) {
+      if (!mem.content || !VALID_TYPES.includes(mem.type)) continue;
+      if ((mem.salience || 0) < 0.5 || (mem.confidence || 0) < 0.6) continue;
+
+      // Check for duplicate content
+      const existing = await prisma.memory.findFirst({
+        where: {
+          userId,
+          agentId,
+          content: { contains: mem.content.substring(0, 30) },
+        },
+      });
+
+      if (!existing) {
+        await prisma.memory.create({
+          data: {
+            userId,
+            agentId,
+            type: mem.type,
+            content: mem.content,
+            salience: Math.min(1, Math.max(0, mem.salience)),
+            confidence: Math.min(1, Math.max(0, mem.confidence)),
+            emotionalWeight: Math.min(1, Math.max(0, mem.emotionalWeight || 0)),
+          },
+        });
+        stored++;
+      }
+    }
+
+    return stored;
+  } catch (err) {
+    console.error("Memory extraction error:", err);
+    return 0;
+  }
+}
+
+/**
+ * Retrieve relevant memories for prompt injection (Layer C).
+ * Combines recency + salience + agent memory bias.
+ */
+export async function retrieveMemories(
+  userId: string,
+  agentId: string,
+  agent: AgentConfig,
+  limit = 10,
+): Promise<{ type: string; content: string }[]> {
+  // Get recent memories
+  const recentMemories = await prisma.memory.findMany({
+    where: { userId, agentId },
+    orderBy: { createdAt: "desc" },
+    take: limit,
+  });
+
+  // Get high-salience memories of types the agent cares about
+  const biasedMemories = await prisma.memory.findMany({
+    where: {
+      userId,
+      agentId,
+      type: { in: agent.memoryBias },
+    },
+    orderBy: { salience: "desc" },
+    take: 5,
+  });
+
+  // Merge and deduplicate
+  const seen = new Set<string>();
+  const merged: { type: string; content: string }[] = [];
+
+  for (const mem of [...biasedMemories, ...recentMemories]) {
+    if (!seen.has(mem.id)) {
+      seen.add(mem.id);
+      merged.push({ type: mem.type, content: mem.content });
+    }
+    if (merged.length >= limit) break;
+  }
+
+  return merged;
+}

--- a/lib/services/mood.ts
+++ b/lib/services/mood.ts
@@ -1,0 +1,89 @@
+import { prisma } from "@/lib/prisma";
+import { AgentConfig } from "@/lib/types";
+
+const ALL_MOODS = ["receptive", "distant", "playful", "demanding", "vulnerable", "curious", "affectionate", "reflective", "jealous_light"];
+
+interface MoodInput {
+  currentMood: string;
+  stage: number;
+  interest: number;
+  trust: number;
+  comfort: number;
+  tension: number;
+  attachment: number;
+  lastInteractionAt: Date;
+}
+
+/**
+ * Rule-based mood engine. Deterministic (no LLM call) for speed and cost.
+ * Mood sits on top of personality — it shifts tone but doesn't override identity.
+ */
+export function computeMood(agent: AgentConfig, state: MoodInput): string {
+  const hoursSinceLastInteraction = (Date.now() - state.lastInteractionAt.getTime()) / (1000 * 60 * 60);
+
+  // Long absence effects
+  if (hoursSinceLastInteraction > 48) {
+    if (state.attachment > 50) return "jealous_light";
+    if (agent.coreTraits.warmth > 0.6) return "curious";
+    return "distant";
+  }
+  if (hoursSinceLastInteraction > 24) {
+    if (state.attachment > 40) return "curious";
+    return "distant";
+  }
+
+  // State-driven mood shifts
+  if (state.tension > 70 && state.comfort < 30) {
+    return "demanding";
+  }
+  if (state.comfort > 60 && state.attachment > 50) {
+    return "affectionate";
+  }
+  if (state.trust > 60 && state.stage >= 3 && Math.random() < 0.15) {
+    return "vulnerable";
+  }
+  if (state.interest > 60 && agent.coreTraits.playfulness > 0.6) {
+    return "playful";
+  }
+  if (state.tension > 50 && state.trust < 40) {
+    return "reflective";
+  }
+
+  // Random mood variation (10% chance to shift from current)
+  if (Math.random() < 0.1) {
+    const validMoods = ALL_MOODS.filter((m) => {
+      // Personality constraints
+      if (m === "vulnerable" && state.stage < 2) return false;
+      if (m === "affectionate" && agent.coreTraits.warmth < 0.4 && state.stage < 3) return false;
+      if (m === "jealous_light" && state.attachment < 30) return false;
+      return m !== state.currentMood;
+    });
+    if (validMoods.length > 0) {
+      return validMoods[Math.floor(Math.random() * validMoods.length)];
+    }
+  }
+
+  // Default: keep current mood, or receptive
+  return state.currentMood || "receptive";
+}
+
+/**
+ * Update mood in the database.
+ */
+export async function updateMood(userId: string, agentId: string, agent: AgentConfig): Promise<string> {
+  const state = await prisma.relationshipState.findUnique({
+    where: { userId_agentId: { userId, agentId } },
+  });
+  if (!state) return "receptive";
+
+  const newMood = computeMood(agent, state);
+
+  if (newMood !== state.currentMood) {
+    await prisma.relationshipState.update({
+      where: { userId_agentId: { userId, agentId } },
+      data: { currentMood: newMood },
+    });
+  }
+
+  return newMood;
+}


### PR DESCRIPTION
## Summary

- **Memory extraction**: GPT-4o-mini analyzes exchanges every 3 turns, extracts facts/preferences/boundaries/jokes/patterns with salience filtering and deduplication
- **Memory retrieval**: Combines recent + high-salience memories, prioritizes agent's `memoryBias` types, injected into prompt Layer C
- **Mood engine**: Rule-based (no LLM), factors in time gap, relationship dimensions, and personality constraints. 10% random variation.
- **Full pipeline**: All 4 prompt layers populated, mood computed pre-prompt, memories loaded in parallel, extraction runs async

## New files
- `lib/services/memory.ts` — extraction + retrieval
- `lib/services/mood.ts` — rule-based mood engine

## Modified files
- `lib/services/chat.ts` — full pipeline with memory + mood integration

## Depends on
PR #8 (Phase 2) should be merged first.

## Test plan
- [ ] Chat 6+ messages → verify memories appear in DB (check Supabase table)
- [ ] Mention a personal fact → chat more → verify agent references it
- [ ] Wait 24h+ (or manually set lastInteractionAt) → verify mood shifts to distant/curious
- [ ] Verify different agents store different memory types (Valeria: patterns, Luna: facts)

https://claude.ai/code/session_01Ma4QyJ8iqoqXtuhgUNY1Z4