### PR TITLE
Issue #44: Add Scenario and ScenarioAttempt schema

### DIFF
--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -107,6 +107,10 @@ export interface AgentConfig {
   responsePatterns: ResponsePatterns;
 }
 
+export type ScenarioDifficulty = "easy" | "normal" | "hard" | "expert";
+export type ScenarioCategory = "opening" | "sustain" | "recovery" | "rejection" | "flirting" | "transition";
+export type ConversationMode = "practice" | "scenario" | "challenge";
+
 // --- Skill Evaluation ---
 
 export interface SkillScores {
@@ -161,8 +165,8 @@ export interface ScenarioData {
   description: string;
   objective: string;
   context: string;
-  difficulty: "easy" | "normal" | "hard" | "expert";
-  category: "opening" | "sustain" | "recovery" | "rejection" | "flirting" | "transition";
+  difficulty: ScenarioDifficulty;
+  category: ScenarioCategory;
   maxMessages?: number;
   timeLimit?: number;
   unlockRequirement?: { minLevel: number };
@@ -200,5 +204,3 @@ export interface Achievement {
   condition: string;
   icon: string;
 }
-
-export type ConversationMode = "practice" | "scenario" | "challenge";

--- a/prisma/migrations/20260410_add_scenarios/migration.sql
+++ b/prisma/migrations/20260410_add_scenarios/migration.sql
@@ -1,0 +1,72 @@
+ALTER TABLE "Conversation" ADD COLUMN IF NOT EXISTS "mode" TEXT NOT NULL DEFAULT 'practice';
+ALTER TABLE "Conversation" ADD COLUMN IF NOT EXISTS "scenarioId" TEXT;
+
+CREATE TABLE IF NOT EXISTS "Scenario" (
+    "id" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "objective" TEXT NOT NULL,
+    "context" TEXT NOT NULL,
+    "difficulty" TEXT NOT NULL DEFAULT 'normal',
+    "category" TEXT NOT NULL,
+    "maxMessages" INTEGER,
+    "timeLimit" INTEGER,
+    "unlockRequirement" JSONB,
+    "agentConstraints" JSONB,
+    "successCriteria" JSONB NOT NULL,
+    "tips" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Scenario_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "Scenario_slug_key" ON "Scenario"("slug");
+CREATE INDEX IF NOT EXISTS "Scenario_isActive_order_idx" ON "Scenario"("isActive", "order");
+CREATE INDEX IF NOT EXISTS "Scenario_category_difficulty_idx" ON "Scenario"("category", "difficulty");
+
+CREATE TABLE IF NOT EXISTS "ScenarioAttempt" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "scenarioId" TEXT NOT NULL,
+    "conversationId" TEXT NOT NULL,
+    "agentId" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'in_progress',
+    "score" JSONB,
+    "feedback" JSONB,
+    "completedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ScenarioAttempt_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "Conversation_mode_createdAt_idx" ON "Conversation"("mode", "createdAt");
+CREATE INDEX IF NOT EXISTS "Conversation_scenarioId_idx" ON "Conversation"("scenarioId");
+CREATE INDEX IF NOT EXISTS "ScenarioAttempt_userId_scenarioId_idx" ON "ScenarioAttempt"("userId", "scenarioId");
+CREATE INDEX IF NOT EXISTS "ScenarioAttempt_userId_status_idx" ON "ScenarioAttempt"("userId", "status");
+CREATE INDEX IF NOT EXISTS "ScenarioAttempt_conversationId_idx" ON "ScenarioAttempt"("conversationId");
+
+DO $$ BEGIN
+  ALTER TABLE "Conversation" ADD CONSTRAINT "Conversation_scenarioId_fkey" FOREIGN KEY ("scenarioId") REFERENCES "Scenario"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "ScenarioAttempt" ADD CONSTRAINT "ScenarioAttempt_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "ScenarioAttempt" ADD CONSTRAINT "ScenarioAttempt_scenarioId_fkey" FOREIGN KEY ("scenarioId") REFERENCES "Scenario"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "ScenarioAttempt" ADD CONSTRAINT "ScenarioAttempt_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "Conversation"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "ScenarioAttempt" ADD CONSTRAINT "ScenarioAttempt_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,24 +42,27 @@ model Agent {
   conversations  Conversation[]
   relationStates RelationshipState[]
   memories       Memory[]
+  attempts       ScenarioAttempt[]
 }
 
 model Conversation {
-  id         String     @id @default(uuid())
-  userId     String
-  agentId    String
-  mode       String     @default("practice") // practice | scenario | challenge
+  id        String    @id @default(uuid())
+  userId    String
+  agentId   String
+  mode      String    @default("practice")
   scenarioId String?
-  createdAt  DateTime   @default(now())
-  updatedAt  DateTime   @updatedAt
-  user       User       @relation(fields: [userId], references: [id])
-  agent      Agent      @relation(fields: [agentId], references: [id])
-  scenario   Scenario?  @relation(fields: [scenarioId], references: [id])
-  messages   Message[]
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+  user      User      @relation(fields: [userId], references: [id])
+  agent     Agent     @relation(fields: [agentId], references: [id])
+  scenario  Scenario? @relation(fields: [scenarioId], references: [id])
+  messages  Message[]
+  attempts  ScenarioAttempt[]
 
-  // Practice mode uses findFirst with mode filter; scenario mode creates new conversations per attempt
   @@index([userId, agentId, mode])
   @@index([userId, agentId, mode, scenarioId])
+  @@index([mode, createdAt])
+  @@index([scenarioId])
 }
 
 model Message {
@@ -140,8 +143,6 @@ model Notification {
   @@index([userId, read, createdAt])
 }
 
-// --- Scenario System ---
-
 model Scenario {
   id                String            @id @default(uuid())
   slug              String            @unique
@@ -149,13 +150,13 @@ model Scenario {
   description       String
   objective         String
   context           String
-  difficulty        String            @default("normal") // easy | normal | hard | expert
-  category          String            // opening | sustain | recovery | rejection | flirting | transition
+  difficulty        String            @default("normal")
+  category          String
   maxMessages       Int?
-  timeLimit         Int?              // seconds
-  unlockRequirement Json?             // e.g. {"minLevel": 3}
-  agentConstraints  Json?             // e.g. {"shortResponses": true, "lowTolerance": true}
-  successCriteria   Json              // e.g. {"minInterest": 60}
+  timeLimit         Int?
+  unlockRequirement Json?
+  agentConstraints  Json?
+  successCriteria   Json
   tips              String[]          @default([])
   order             Int               @default(0)
   isActive          Boolean           @default(true)
@@ -163,48 +164,48 @@ model Scenario {
   attempts          ScenarioAttempt[]
   conversations     Conversation[]
 
-  @@index([category])
-  @@index([difficulty])
+  @@index([isActive, order])
+  @@index([category, difficulty])
 }
 
 model ScenarioAttempt {
-  id             String    @id @default(uuid())
+  id             String       @id @default(uuid())
   userId         String
   scenarioId     String
   conversationId String
   agentId        String
-  status         String    @default("in_progress") // in_progress | completed | abandoned
-  score          Json?     // per-skill scores
-  feedback       Json?     // structured post-session feedback
-  xpEarned       Int       @default(0)
+  status         String       @default("in_progress")
+  score          Json?
+  feedback       Json?
   completedAt    DateTime?
-  createdAt      DateTime  @default(now())
-  user           User      @relation(fields: [userId], references: [id])
-  scenario       Scenario  @relation(fields: [scenarioId], references: [id])
+  createdAt      DateTime     @default(now())
+  user           User         @relation(fields: [userId], references: [id])
+  scenario       Scenario     @relation(fields: [scenarioId], references: [id])
+  conversation   Conversation @relation(fields: [conversationId], references: [id])
+  agent          Agent        @relation(fields: [agentId], references: [id])
 
   @@index([userId, scenarioId])
   @@index([userId, status])
+  @@index([conversationId])
 }
 
-// --- User Skill & Progression ---
-
 model UserSkillScore {
-  id                       String   @id @default(uuid())
-  userId                   String   @unique
-  confidence               Float    @default(50)
-  warmth                   Float    @default(50)
-  curiosity                Float    @default(50)
-  calibration              Float    @default(50)
-  authenticity             Float    @default(50)
-  pressureLevel            Float    @default(50) // inverse: lower is better
-  awkwardness              Float    @default(50) // inverse: lower is better
-  emotionalIntelligence    Float    @default(50)
-  boundaryRespect          Float    @default(50)
-  conversationalMomentum   Float    @default(50)
-  overallScore             Float    @default(50)
-  totalSessions            Int      @default(0)
-  updatedAt                DateTime @updatedAt
-  user                     User     @relation(fields: [userId], references: [id])
+  id                     String   @id @default(uuid())
+  userId                 String   @unique
+  confidence             Float    @default(50)
+  warmth                 Float    @default(50)
+  curiosity              Float    @default(50)
+  calibration            Float    @default(50)
+  authenticity           Float    @default(50)
+  pressureLevel          Float    @default(50)
+  awkwardness            Float    @default(50)
+  emotionalIntelligence  Float    @default(50)
+  boundaryRespect        Float    @default(50)
+  conversationalMomentum Float    @default(50)
+  overallScore           Float    @default(50)
+  totalSessions          Int      @default(0)
+  updatedAt              DateTime @updatedAt
+  user                   User     @relation(fields: [userId], references: [id])
 }
 
 model UserProgress {


### PR DESCRIPTION
## Summary
- add `Scenario` and `ScenarioAttempt` models with indexes for gameplay queries
- extend `Conversation` with `mode` and `scenarioId` relations
- extend shared TypeScript types with scenario mode/domain contracts

## Test plan
- [x] Run `npx prisma generate`
- [x] Validate schema compiles with new relations
- [ ] Apply migration in a connected DB environment

Made with [Cursor](https://cursor.com)