### PR TITLE
Refactor home to action-first dashboard core

### DIFF
--- a/app/components/dashboard/ContinueTrainingCard.tsx
+++ b/app/components/dashboard/ContinueTrainingCard.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { ArrowRight, PlayCircle } from "lucide-react";
+
+interface ContinueTrainingCardProps {
+  title: string;
+  subtitle: string;
+  href: string;
+  updatedAt: string | null;
+}
+
+export default function ContinueTrainingCard({
+  title,
+  subtitle,
+  href,
+  updatedAt,
+}: ContinueTrainingCardProps) {
+  const updatedLabel = updatedAt
+    ? new Date(updatedAt).toLocaleString("en-US", {
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      })
+    : "No previous session";
+
+  return (
+    <section className="rounded-2xl border border-base-500/40 bg-base-800/85 p-5 backdrop-blur-md shadow-surface-1">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="mb-1 text-xs uppercase tracking-wider text-base-400">Continue Training</p>
+          <h2 className="font-display text-xl font-semibold text-base-50">{title}</h2>
+          <p className="mt-1 text-sm text-base-300">{subtitle}</p>
+          <p className="mt-2 text-xs text-base-400">Last activity: {updatedLabel}</p>
+        </div>
+        <PlayCircle className="mt-1 text-mira-400" size={22} />
+      </div>
+      <a
+        href={href}
+        className="mt-4 inline-flex items-center gap-2 rounded-lg bg-mira-500 px-3.5 py-2 text-sm font-medium text-white transition hover:bg-mira-400"
+      >
+        Continue now
+        <ArrowRight size={14} />
+      </a>
+    </section>
+  );
+}

--- a/app/components/dashboard/ProgressSnapshot.tsx
+++ b/app/components/dashboard/ProgressSnapshot.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Flame, Target, TrendingUp } from "lucide-react";
+
+interface ProgressSnapshotProps {
+  level: number;
+  tierLabel: string;
+  xp: number;
+  xpInCurrentLevel: number;
+  xpSpan: number;
+  xpPercent: number;
+  streakDays: number;
+  overallScore: number | null;
+  totalSessions: number;
+  scenariosCompleted: number;
+}
+
+export default function ProgressSnapshot(props: ProgressSnapshotProps) {
+  return (
+    <section className="rounded-2xl border border-base-500/40 bg-base-800/85 p-5 backdrop-blur-md shadow-surface-1">
+      <p className="mb-3 text-xs uppercase tracking-wider text-base-400">Progress Snapshot</p>
+      <div className="mb-3 flex flex-wrap items-center gap-2">
+        <span className="rounded-full bg-base-700/80 px-2.5 py-1 text-xs text-base-200">
+          Level {props.level}
+        </span>
+        <span className="rounded-full bg-base-700/80 px-2.5 py-1 text-xs text-base-300">
+          {props.tierLabel}
+        </span>
+        <span className="rounded-full bg-base-700/80 px-2.5 py-1 text-xs text-base-300">
+          {props.xp} XP total
+        </span>
+      </div>
+      <div className="mb-2 flex items-center justify-between text-xs text-base-300">
+        <span>{props.xpInCurrentLevel} / {props.xpSpan} XP</span>
+        <span>{props.xpPercent}%</span>
+      </div>
+      <div className="h-2 overflow-hidden rounded-full bg-base-600/80">
+        <div className="h-full rounded-full bg-gradient-to-r from-mira-500 to-mira-300" style={{ width: `${props.xpPercent}%` }} />
+      </div>
+      <div className="mt-4 grid grid-cols-3 gap-2 text-center text-xs">
+        <div className="rounded-lg bg-base-700/60 p-2 text-base-200">
+          <Flame size={14} className="mx-auto mb-1 text-amber-400" />
+          {props.streakDays} streak
+        </div>
+        <div className="rounded-lg bg-base-700/60 p-2 text-base-200">
+          <Target size={14} className="mx-auto mb-1 text-emerald-400" />
+          {props.scenariosCompleted} scenarios
+        </div>
+        <div className="rounded-lg bg-base-700/60 p-2 text-base-200">
+          <TrendingUp size={14} className="mx-auto mb-1 text-sky-400" />
+          {props.overallScore === null ? "--" : Math.round(props.overallScore)}
+        </div>
+      </div>
+      <p className="mt-2 text-center text-xs text-base-400">{props.totalSessions} sessions completed</p>
+    </section>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,145 +1,64 @@
-import AgentCard from "./components/AgentCard";
-import HomeHero from "./components/HomeHero";
-import RecentActivity from "./components/RecentActivity";
-import { getAllAgents } from "@/lib/agents";
-import { prisma } from "@/lib/prisma";
 import { getAuthUser } from "@/lib/supabase/server";
+import { getOrCreateUser } from "@/lib/services/auth";
+import { getDashboardViewModel } from "@/lib/services/dashboard";
+import ContinueTrainingCard from "./components/dashboard/ContinueTrainingCard";
+import ProgressSnapshot from "./components/dashboard/ProgressSnapshot";
+import TodaysPlan from "./components/dashboard/TodaysPlan";
+import SkillFocusCard from "./components/dashboard/SkillFocusCard";
+import RecentSessionsPanel from "./components/dashboard/RecentSessionsPanel";
+import InsightsPanel from "./components/dashboard/InsightsPanel";
+import SwitchCharacterBar from "./components/dashboard/SwitchCharacterBar";
 
 export default async function Home() {
-  const agents = getAllAgents();
   const authUser = await getAuthUser();
-
-  // Default progress values for unauthenticated users
-  let level = 1;
-  let xp = 0;
-  let xpToNextLevel = 100;
-  let streakDays = 0;
-  let overallScore: number | null = null;
-  let isLoggedIn = false;
-  let recentSessions: { agentName: string; mode: string; date: string; score?: number | null }[] = [];
-
-  // Fetch relationship stages and unread counts for authenticated user
-  let stages: Record<string, number> = {};
-  let unreads: Record<string, number> = {};
-
-  if (authUser) {
-    const user = await prisma.user.findUnique({ where: { authId: authUser.id } });
-    if (user) {
-      isLoggedIn = true;
-
-      const [states, notifications, progress, skillScore, conversations] = await Promise.all([
-        prisma.relationshipState.findMany({
-          where: { userId: user.id },
-          select: { agentId: true, stage: true },
-        }),
-        prisma.notification.groupBy({
-          by: ["agentId"],
-          where: { userId: user.id, read: false },
-          _count: { id: true },
-        }),
-        prisma.userProgress.findUnique({
-          where: { userId: user.id },
-        }),
-        prisma.userSkillScore.findUnique({
-          where: { userId: user.id },
-        }),
-        prisma.conversation.findMany({
-          where: { userId: user.id },
-          orderBy: { updatedAt: "desc" },
-          take: 3,
-          select: {
-            agentId: true,
-            mode: true,
-            updatedAt: true,
-          },
-        }),
-      ]);
-
-      stages = Object.fromEntries(states.map((s) => [s.agentId, s.stage]));
-      unreads = Object.fromEntries(notifications.map((n) => [n.agentId, n._count.id]));
-
-      if (progress) {
-        level = progress.level;
-        xp = progress.xp;
-        xpToNextLevel = progress.xpToNextLevel;
-        streakDays = progress.streakDays;
-      }
-
-      if (skillScore) {
-        overallScore = skillScore.overallScore;
-      }
-
-      // Build agent name lookup
-      const agentMap = Object.fromEntries(agents.map((a) => [a.id, a.name]));
-
-      recentSessions = conversations.map((c) => ({
-        agentName: agentMap[c.agentId] || c.agentId,
-        mode: c.mode,
-        date: c.updatedAt.toISOString(),
-      }));
-    }
-  }
+  const dashboard = authUser
+    ? await getDashboardViewModel((await getOrCreateUser(authUser)).id)
+    : null;
 
   return (
     <div className="relative min-h-[calc(100vh-73px)] overflow-hidden">
-      {/* Ambient background */}
       <div className="pointer-events-none absolute inset-0">
         <div className="absolute left-1/4 top-0 h-[500px] w-[600px] rounded-full bg-mira-500/[0.06] blur-[120px]" />
         <div className="absolute right-1/4 top-20 h-[400px] w-[500px] rounded-full bg-sable-500/[0.05] blur-[100px]" />
         <div className="absolute bottom-0 left-1/2 h-[300px] w-[800px] -translate-x-1/2 rounded-full bg-valeria-500/[0.04] blur-[120px]" />
       </div>
 
-      <div className="relative mx-auto max-w-4xl px-6 py-12">
-        {/* Hero */}
-        {isLoggedIn ? (
-          <HomeHero
-            level={level}
-            xp={xp}
-            xpToNextLevel={xpToNextLevel}
-            streakDays={streakDays}
-            overallScore={overallScore}
-          />
-        ) : (
-          <div className="mb-10 text-center">
-            <h1 className="mb-3 font-display text-4xl font-bold italic text-base-50">
-              Simulador de Conversas
+      <div className="relative mx-auto max-w-5xl px-6 py-10">
+        {!dashboard ? (
+          <div className="rounded-2xl border border-base-500/40 bg-base-800/85 p-8 text-center backdrop-blur-md">
+            <h1 className="mb-2 font-display text-3xl font-semibold text-base-50">
+              Train social conversations with purpose
             </h1>
-            <p className="mx-auto max-w-md text-base-300">
-              Pratica comunicação, confiança e leitura social com perfis interpessoais diferentes num simulador gamificado.
+            <p className="mx-auto max-w-xl text-base-300">
+              Sign in to unlock your action-first dashboard with progress insights, focused plans, and quick replay loops.
             </p>
+            <a
+              href="/login"
+              className="mt-5 inline-flex rounded-lg bg-mira-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-mira-400"
+            >
+              Sign in
+            </a>
           </div>
-        )}
-
-        {/* Characters heading */}
-        <div className="mb-6 text-center">
-          <h2 className="mb-2 font-display text-2xl font-semibold italic text-base-50">
-            Escolhe a tua Personagem
-          </h2>
-          <p className="mx-auto max-w-lg text-sm text-base-300">
-            Cinco perfis interpessoais distintos. Cada um com o seu ritmo, estilo e forma de comunicar.
-          </p>
-        </div>
-
-        {/* Agent grid */}
-        <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
-          {agents.map((agent) => (
-            <AgentCard
-              key={agent.id}
-              id={agent.id}
-              name={agent.name}
-              shortBio={agent.shortBio}
-              archetype={agent.archetype}
-              vibeTags={agent.vibeTags}
-              avatar={agent.avatar}
-              stage={stages[agent.id] ?? null}
-              unreadCount={unreads[agent.id] ?? 0}
+        ) : (
+          <div className="space-y-4">
+            <ContinueTrainingCard
+              title={dashboard.continueTraining.title}
+              subtitle={dashboard.continueTraining.subtitle}
+              href={dashboard.continueTraining.href}
+              updatedAt={dashboard.continueTraining.updatedAt}
             />
-          ))}
-        </div>
-
-        {/* Recent Activity */}
-        {isLoggedIn && recentSessions.length > 0 && (
-          <RecentActivity sessions={recentSessions} />
+            <ProgressSnapshot {...dashboard.progressSnapshot} />
+            <TodaysPlan actions={dashboard.todayPlan} />
+            <SkillFocusCard
+              label={dashboard.skillFocus.label}
+              score={dashboard.skillFocus.score}
+              recommendation={dashboard.skillFocus.recommendation}
+              href={dashboard.skillFocus.href}
+            />
+            <RecentSessionsPanel sessions={dashboard.recentSessions} />
+            <InsightsPanel insights={dashboard.insights} />
+            <SwitchCharacterBar agents={dashboard.switchCharacter} />
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- refactor `app/page.tsx` to the action-first dashboard composition
- add `ContinueTrainingCard` and `ProgressSnapshot` UI blocks
- move agent selection out of primary top-of-page emphasis

## Test plan
- [x] read lints for edited files
- [ ] run full lint locally with Node >= 18.17
- [ ] verify home sections render in expected order

Closes #74
Closes #75

Made with [Cursor](https://cursor.com)