### PR TITLE
Add dashboard intelligence sections

### DIFF
--- a/app/components/dashboard/InsightsPanel.tsx
+++ b/app/components/dashboard/InsightsPanel.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Lightbulb } from "lucide-react";
+
+interface InsightsPanelProps {
+  insights: string[];
+}
+
+export default function InsightsPanel({ insights }: InsightsPanelProps) {
+  return (
+    <section className="rounded-2xl border border-base-500/40 bg-base-800/85 p-5 backdrop-blur-md shadow-surface-1">
+      <div className="mb-3 flex items-center gap-2">
+        <Lightbulb size={16} className="text-amber-300" />
+        <p className="text-xs uppercase tracking-wider text-base-400">Insights</p>
+      </div>
+      <ul className="space-y-2">
+        {insights.map((insight) => (
+          <li key={insight} className="rounded-lg bg-base-700/50 px-3 py-2 text-sm text-base-200">
+            {insight}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/app/components/dashboard/RecentSessionsPanel.tsx
+++ b/app/components/dashboard/RecentSessionsPanel.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+interface RecentSessionItem {
+  conversationId: string;
+  agentName: string;
+  mode: string;
+  updatedAt: string;
+  scenarioTitle: string | null;
+  adjustedScore: number | null;
+  rawScore: number | null;
+  hintsUsed: number;
+  directHintUses: number;
+  hintPenaltyScore: number;
+  hintPenaltyXp: number;
+}
+
+interface RecentSessionsPanelProps {
+  sessions: RecentSessionItem[];
+}
+
+export default function RecentSessionsPanel({ sessions }: RecentSessionsPanelProps) {
+  return (
+    <section className="rounded-2xl border border-base-500/40 bg-base-800/85 p-5 backdrop-blur-md shadow-surface-1">
+      <p className="mb-3 text-xs uppercase tracking-wider text-base-400">Recent Sessions</p>
+      {sessions.length === 0 ? (
+        <p className="text-sm text-base-300">No sessions yet. Start one to populate your dashboard.</p>
+      ) : (
+        <div className="space-y-2">
+          {sessions.slice(0, 5).map((session) => (
+            <div key={session.conversationId} className="rounded-xl border border-base-600/60 bg-base-700/40 p-3">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <p className="text-sm font-medium text-base-100">
+                  {session.agentName} • {session.mode}
+                </p>
+                <p className="text-xs text-base-300">
+                  {new Date(session.updatedAt).toLocaleDateString("en-US")}
+                </p>
+              </div>
+              {session.scenarioTitle && (
+                <p className="mt-1 text-xs text-base-300">Scenario: {session.scenarioTitle}</p>
+              )}
+              <p className="mt-1 text-xs text-base-300">
+                Adjusted score: {session.adjustedScore === null ? "--" : Math.round(session.adjustedScore)}
+                {" • "}
+                Raw score: {session.rawScore === null ? "--" : Math.round(session.rawScore)}
+              </p>
+              <p className="mt-1 text-xs text-base-400">
+                Hints: {session.hintsUsed} (direct: {session.directHintUses}) • Penalty: -
+                {session.hintPenaltyScore.toFixed(1)} score / -{session.hintPenaltyXp} XP
+              </p>
+              <div className="mt-2 flex gap-2 text-xs">
+                <a href={`/replay/${session.conversationId}`} className="text-mira-300 hover:text-mira-200">
+                  Replay
+                </a>
+                <a href={`/analysis/${session.conversationId}`} className="text-mira-300 hover:text-mira-200">
+                  Analysis
+                </a>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/components/dashboard/SkillFocusCard.tsx
+++ b/app/components/dashboard/SkillFocusCard.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { BrainCircuit } from "lucide-react";
+
+interface SkillFocusCardProps {
+  label: string;
+  score: number | null;
+  recommendation: string;
+  href: string;
+}
+
+export default function SkillFocusCard({ label, score, recommendation, href }: SkillFocusCardProps) {
+  return (
+    <section className="rounded-2xl border border-base-500/40 bg-base-800/85 p-5 backdrop-blur-md shadow-surface-1">
+      <div className="mb-3 flex items-center gap-2">
+        <BrainCircuit size={16} className="text-violet-300" />
+        <p className="text-xs uppercase tracking-wider text-base-400">Skill Focus</p>
+      </div>
+      <h3 className="text-lg font-semibold text-base-100">{label}</h3>
+      <p className="mt-1 text-xs text-base-300">
+        Current effective score: {score === null ? "--" : score}
+      </p>
+      <p className="mt-3 text-sm text-base-200">{recommendation}</p>
+      <a
+        href={href}
+        className="mt-4 inline-flex rounded-lg bg-base-700 px-3 py-2 text-sm text-base-100 transition hover:bg-base-600"
+      >
+        Open focused practice
+      </a>
+    </section>
+  );
+}

--- a/app/components/dashboard/TodaysPlan.tsx
+++ b/app/components/dashboard/TodaysPlan.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { CalendarCheck2 } from "lucide-react";
+import type { DashboardAction } from "@/lib/services/dashboard";
+
+interface TodaysPlanProps {
+  actions: DashboardAction[];
+}
+
+export default function TodaysPlan({ actions }: TodaysPlanProps) {
+  return (
+    <section className="rounded-2xl border border-base-500/40 bg-base-800/85 p-5 backdrop-blur-md shadow-surface-1">
+      <div className="mb-3 flex items-center gap-2">
+        <CalendarCheck2 size={16} className="text-mira-300" />
+        <p className="text-xs uppercase tracking-wider text-base-400">Today&apos;s Plan</p>
+      </div>
+      <div className="space-y-2">
+        {actions.map((action, index) => (
+          <a
+            key={action.id}
+            href={action.href}
+            className="block rounded-xl border border-base-600/60 bg-base-700/40 p-3 transition hover:border-base-500 hover:bg-base-700/70"
+          >
+            <p className="text-xs text-base-400">Step {index + 1}</p>
+            <p className="text-sm font-medium text-base-100">{action.title}</p>
+            <p className="mt-0.5 text-xs text-base-300">{action.description}</p>
+          </a>
+        ))}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add `TodaysPlan` and `SkillFocusCard` for daily action + weak-skill targeting
- add `RecentSessionsPanel` and `InsightsPanel` for adjusted-score feedback loop
- include replay/analysis quick links in recent sessions

## Test plan
- [x] read lints for edited files
- [ ] run full lint locally with Node >= 18.17
- [ ] verify data rendering with and without history

Closes #76
Closes #77

Made with [Cursor](https://cursor.com)