### PR TITLE
Fix dashboard TypeScript narrowing in insights delta

### DIFF
--- a/lib/services/dashboard.ts
+++ b/lib/services/dashboard.ts
@@ -280,8 +280,10 @@ export async function getDashboardViewModel(userId: string): Promise<DashboardVi
     recentSessions.filter((item) => item.adjustedScore !== null)[1] ?? null;
 
   const insights: string[] = [];
-  if (latestScored?.adjustedScore !== null && previousScored?.adjustedScore !== null) {
-    const delta = latestScored.adjustedScore - previousScored.adjustedScore;
+  const latestAdjusted = latestScored?.adjustedScore;
+  const previousAdjusted = previousScored?.adjustedScore;
+  if (typeof latestAdjusted === "number" && typeof previousAdjusted === "number") {
+    const delta = latestAdjusted - previousAdjusted;
     if (delta >= 3) {
       insights.push(`Adjusted score improved by ${delta.toFixed(1)} in your latest session.`);
     } else if (delta <= -3) {


### PR DESCRIPTION
## Summary
- fix nullable narrowing in `lib/services/dashboard.ts` insight delta calculation
- use explicit numeric guards before subtraction
- unblock `npm run build` TypeScript validation for dashboard service

## Test plan
- [x] verify targeted diff for `lib/services/dashboard.ts`
- [ ] run `npm run build` in CI/preview

Made with [Cursor](https://cursor.com)