### PR TITLE
Finalize hint penalty tracking across chat, scoring, and feedback

### DIFF
--- a/app/api/chat/stream/route.ts
+++ b/app/api/chat/stream/route.ts
@@ -7,6 +7,7 @@ import { checkStageProgression } from "@/lib/services/stage";
 import { retrieveMemories, extractMemories } from "@/lib/services/memory";
 import { updateMood } from "@/lib/services/mood";
 import { checkMilestones } from "@/lib/services/milestone";
+import { trackDirectHintUse } from "@/lib/services/hint-usage";
 import { config } from "@/lib/config";
 import { z } from "zod";
 import OpenAI from "openai";
@@ -83,6 +84,7 @@ export async function POST(req: NextRequest) {
   await prisma.message.create({
     data: { conversationId: conversation.id, senderRole: "user", content: message },
   });
+  await trackDirectHintUse(conversation.id, message);
 
   // Load last 15 messages (down from 30) + memories
   const [recentMessagesDesc, memories] = await Promise.all([

--- a/app/api/evaluate/route.ts
+++ b/app/api/evaluate/route.ts
@@ -83,6 +83,7 @@ export async function POST(req: NextRequest) {
     const progressBefore = await getOrCreateProgress(user.id);
     const sessionMeta = (conversation.sessionMeta as Record<string, unknown> | null) ?? {};
     const hintsUsed = typeof sessionMeta.hintsUsed === "number" ? sessionMeta.hintsUsed : 0;
+    const directHintUses = typeof sessionMeta.directHintUses === "number" ? sessionMeta.directHintUses : 0;
 
     // Raw XP before hint penalty
     let rawXp = XP_REWARDS.completePracticeSession;
@@ -97,6 +98,7 @@ export async function POST(req: NextRequest) {
       rawXp,
       level: progressBefore.level,
       hintsUsed,
+      directHintUses,
       mode: "practice",
     });
 
@@ -104,8 +106,11 @@ export async function POST(req: NextRequest) {
     feedback.adjustedOverallScore = adjusted.adjustedScore;
     feedback.overallScore = adjusted.adjustedScore;
     feedback.hintsUsed = adjusted.breakdown.hintsUsed;
+    feedback.directHintUses = adjusted.breakdown.directHintUses;
     feedback.hintPenaltyScore = adjusted.breakdown.scorePenalty;
+    feedback.directHintPenaltyScore = adjusted.breakdown.directScorePenalty;
     feedback.hintPenaltyXp = adjusted.breakdown.xpPenalty;
+    feedback.directHintPenaltyXp = adjusted.breakdown.directXpPenalty;
     feedback.rawXp = adjusted.rawXp;
     feedback.adjustedXp = adjusted.adjustedXp;
 

--- a/app/api/scenarios/complete/route.ts
+++ b/app/api/scenarios/complete/route.ts
@@ -122,6 +122,14 @@ export async function POST(req: NextRequest) {
 
     const progressBefore = await getOrCreateProgress(user.id);
     const hintsUsed = attempt.hintsUsed ?? 0;
+    const conversationMeta = (await prisma.conversation.findUnique({
+      where: { id: attempt.conversationId },
+      select: { sessionMeta: true },
+    }))?.sessionMeta as Record<string, unknown> | null;
+    const directHintUses =
+      conversationMeta && typeof conversationMeta.directHintUses === "number"
+        ? conversationMeta.directHintUses
+        : 0;
 
     // Raw XP before hint penalty
     let rawXp = completionResult.success
@@ -139,6 +147,7 @@ export async function POST(req: NextRequest) {
       rawXp,
       level: progressBefore.level,
       hintsUsed,
+      directHintUses,
       mode: attempt.scenario.difficulty === "expert" ? "challenge" : "scenario",
     });
 
@@ -146,8 +155,11 @@ export async function POST(req: NextRequest) {
     feedback.adjustedOverallScore = adjusted.adjustedScore;
     feedback.overallScore = adjusted.adjustedScore;
     feedback.hintsUsed = adjusted.breakdown.hintsUsed;
+    feedback.directHintUses = adjusted.breakdown.directHintUses;
     feedback.hintPenaltyScore = adjusted.breakdown.scorePenalty;
+    feedback.directHintPenaltyScore = adjusted.breakdown.directScorePenalty;
     feedback.hintPenaltyXp = adjusted.breakdown.xpPenalty;
+    feedback.directHintPenaltyXp = adjusted.breakdown.directXpPenalty;
     feedback.rawXp = adjusted.rawXp;
     feedback.adjustedXp = adjusted.adjustedXp;
 
@@ -168,6 +180,8 @@ export async function POST(req: NextRequest) {
         hintsUsed: adjusted.breakdown.hintsUsed,
         hintPenaltyScore: adjusted.breakdown.scorePenalty,
         hintPenaltyXp: adjusted.breakdown.xpPenalty,
+        directHintPenaltyScore: adjusted.breakdown.directScorePenalty,
+        directHintPenaltyXp: adjusted.breakdown.directXpPenalty,
         rawOverallScore: adjusted.rawScore,
         adjustedOverallScore: adjusted.adjustedScore,
       }

--- a/app/components/ChatWindow.tsx
+++ b/app/components/ChatWindow.tsx
@@ -194,6 +194,7 @@ export default function ChatWindow({
     if (hintLoading) return;
     if (Date.now() < hintCooldownUntil) return;
     setHintLoading(true);
+    setHintData(null);
     setHintError(null);
     try {
       const res = await fetch("/api/chat/hint", {
@@ -535,12 +536,27 @@ export default function ChatWindow({
           </div>
           {(hintData || hintError) && (
             <div className="mx-auto mt-2 max-w-2xl rounded-xl border border-[var(--agent-accent)]/25 bg-[var(--agent-subtle)] p-3 text-xs text-base-200">
+              <div className="mb-2 flex items-center justify-between">
+                <p className="text-[11px] font-semibold text-[var(--agent-accent)]">
+                  Dica Contextual
+                </p>
+                <button
+                  onClick={() => {
+                    setHintData(null);
+                    setHintError(null);
+                  }}
+                  className="rounded-md p-1 text-base-400 transition-colors hover:bg-base-700/50 hover:text-base-100"
+                  title="Fechar dica"
+                >
+                  <X size={12} />
+                </button>
+              </div>
               {hintError ? (
                 <p className="text-rose-300">{hintError}</p>
               ) : (
                 <>
                   <p className="mb-1 text-[11px] text-base-300">
-                    <span className="font-semibold text-[var(--agent-accent)]">Porque:</span>{" "}
+                    <span className="font-semibold text-[var(--agent-accent)]">Because:</span>{" "}
                     {hintData?.reason}
                   </p>
                   <p className="mb-2 text-sm font-medium text-base-100">{hintData?.hint}</p>

--- a/app/components/ScenarioComplete.tsx
+++ b/app/components/ScenarioComplete.tsx
@@ -17,8 +17,11 @@ interface ScenarioCompleteProps {
   rawScore?: number;
   rawXp?: number;
   hintsUsed?: number;
+  directHintUses?: number;
   hintPenaltyScore?: number;
+  directHintPenaltyScore?: number;
   hintPenaltyXp?: number;
+  directHintPenaltyXp?: number;
   leveledUp: boolean;
   newLevel?: number;
   achievements: Achievement[];
@@ -95,8 +98,11 @@ export default function ScenarioComplete({
   rawScore,
   rawXp,
   hintsUsed = 0,
+  directHintUses = 0,
   hintPenaltyScore = 0,
+  directHintPenaltyScore = 0,
   hintPenaltyXp = 0,
+  directHintPenaltyXp = 0,
   leveledUp,
   newLevel,
   achievements,
@@ -248,8 +254,9 @@ export default function ScenarioComplete({
               >
                 <p className="mb-1 font-semibold text-base-200">Impacto das dicas</p>
                 <p>Dicas usadas: {hintsUsed}</p>
-                <p>Score bruto/final: {rawScore ?? overallScore} / {overallScore} (-{hintPenaltyScore.toFixed(2)})</p>
-                <p>XP bruto/final: {rawXp ?? xpEarned} / {xpEarned} (-{hintPenaltyXp})</p>
+                <p>Dicas usadas sem adaptação: {directHintUses}</p>
+                <p>Score bruto/final: {rawScore ?? overallScore} / {overallScore} (-{(hintPenaltyScore + directHintPenaltyScore).toFixed(2)})</p>
+                <p>XP bruto/final: {rawXp ?? xpEarned} / {xpEarned} (-{hintPenaltyXp + directHintPenaltyXp})</p>
               </motion.div>
             )}
 

--- a/app/components/SessionFeedback.tsx
+++ b/app/components/SessionFeedback.tsx
@@ -261,7 +261,13 @@ export default function SessionFeedback({ feedback }: SessionFeedbackProps) {
           </h3>
           <div className="grid gap-2 text-sm sm:grid-cols-2">
             <p className="text-base-200">Dicas usadas: <span className="font-semibold">{feedback.hintsUsed}</span></p>
+            {typeof feedback.directHintUses === "number" && (
+              <p className="text-base-200">Dicas usadas sem adaptação: <span className="font-semibold">{feedback.directHintUses}</span></p>
+            )}
             <p className="text-base-200">Penalty score: <span className="font-semibold">-{(feedback.hintPenaltyScore ?? 0).toFixed(2)}</span></p>
+            {typeof feedback.directHintPenaltyScore === "number" && (
+              <p className="text-base-200">Penalty score (uso direto): <span className="font-semibold">-{feedback.directHintPenaltyScore.toFixed(2)}</span></p>
+            )}
             <p className="text-base-200">Score bruto: <span className="font-semibold">{feedback.rawOverallScore ?? feedback.overallScore}</span></p>
             <p className="text-base-200">Score final: <span className="font-semibold">{feedback.adjustedOverallScore ?? feedback.overallScore}</span></p>
             {typeof feedback.rawXp === "number" && (
@@ -269,6 +275,9 @@ export default function SessionFeedback({ feedback }: SessionFeedbackProps) {
             )}
             {typeof feedback.adjustedXp === "number" && (
               <p className="text-base-200">XP final: <span className="font-semibold">{feedback.adjustedXp}</span></p>
+            )}
+            {typeof feedback.directHintPenaltyXp === "number" && (
+              <p className="text-base-200">Penalty XP (uso direto): <span className="font-semibold">-{feedback.directHintPenaltyXp}</span></p>
             )}
           </div>
         </motion.section>

--- a/lib/services/chat.ts
+++ b/lib/services/chat.ts
@@ -7,6 +7,7 @@ import { checkStageProgression } from "./stage";
 import { retrieveMemories, extractMemories } from "./memory";
 import { updateMood } from "./mood";
 import { ConversationMode, AgentConstraints } from "@/lib/types";
+import { trackDirectHintUse } from "./hint-usage";
 
 export interface SendMessageParams {
   userId: string;
@@ -63,6 +64,7 @@ export async function sendMessage(params: SendMessageParams): Promise<SendMessag
   const mood = await updateMood(userId, agentId, agent);
 
   // 3. Store user message
+  await trackDirectHintUse(conversation.id, message);
   await prisma.message.create({
     data: {
       conversationId: conversation.id,

--- a/lib/services/hint-usage.ts
+++ b/lib/services/hint-usage.ts
@@ -1,0 +1,92 @@
+import { prisma } from "@/lib/prisma";
+
+function normalize(text: string): string {
+  return text
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function tokenSimilarity(a: string, b: string): number {
+  const aTokens = normalize(a).split(" ").filter(Boolean);
+  const bTokens = normalize(b).split(" ").filter(Boolean);
+  if (!aTokens.length || !bTokens.length) return 0;
+  const bSet = new Set(bTokens);
+  let overlap = 0;
+  for (const token of aTokens) {
+    if (bSet.has(token)) overlap += 1;
+  }
+  return overlap / Math.max(aTokens.length, bTokens.length);
+}
+
+function isDirectHintUsage(message: string, suggestions: string[]): boolean {
+  const normalizedMessage = normalize(message);
+  if (!normalizedMessage) return false;
+  for (const suggestion of suggestions) {
+    const normalizedSuggestion = normalize(suggestion);
+    if (!normalizedSuggestion) continue;
+    if (normalizedMessage === normalizedSuggestion) return true;
+    if (tokenSimilarity(normalizedMessage, normalizedSuggestion) >= 0.9) return true;
+  }
+  return false;
+}
+
+function toSessionMeta(value: unknown): Record<string, unknown> {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+}
+
+function readStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
+}
+
+export async function appendHintSuggestions(conversationId: string, suggestions: string[]): Promise<void> {
+  if (!suggestions.length) return;
+  const conversation = await prisma.conversation.findUnique({
+    where: { id: conversationId },
+    select: { sessionMeta: true },
+  });
+  const meta = toSessionMeta(conversation?.sessionMeta);
+  const existing = readStringArray(meta.hintSuggestionHistory);
+  const next = [...existing, ...suggestions].slice(-40);
+  await prisma.conversation.update({
+    where: { id: conversationId },
+    data: {
+      sessionMeta: {
+        ...meta,
+        hintSuggestionHistory: next,
+      },
+    },
+  });
+}
+
+export async function trackDirectHintUse(conversationId: string, userMessage: string): Promise<number> {
+  const conversation = await prisma.conversation.findUnique({
+    where: { id: conversationId },
+    select: { sessionMeta: true },
+  });
+  const meta = toSessionMeta(conversation?.sessionMeta);
+  const suggestions = readStringArray(meta.hintSuggestionHistory);
+  const currentDirect = typeof meta.directHintUses === "number" ? meta.directHintUses : 0;
+
+  if (!suggestions.length || !isDirectHintUsage(userMessage, suggestions)) {
+    return currentDirect;
+  }
+
+  const nextDirect = currentDirect + 1;
+  await prisma.conversation.update({
+    where: { id: conversationId },
+    data: {
+      sessionMeta: {
+        ...meta,
+        directHintUses: nextDirect,
+      },
+    },
+  });
+  return nextDirect;
+}

--- a/lib/services/hint.ts
+++ b/lib/services/hint.ts
@@ -5,6 +5,7 @@ import { getAgent } from "@/lib/agents";
 import { getOrCreateState } from "@/lib/services/relationship";
 import { retrieveMemories } from "@/lib/services/memory";
 import type { ConversationMode } from "@/lib/types";
+import { appendHintSuggestions } from "@/lib/services/hint-usage";
 
 const openai = new OpenAI({ apiKey: config.openaiApiKey });
 
@@ -151,6 +152,9 @@ export async function generateContextualHint(input: GenerateHintInput): Promise<
   };
 
   const hintsUsed = await incrementHintsUsed(input, conversationId);
+  if (conversationId) {
+    await appendHintSuggestions(conversationId, (parsed.suggestions || []).slice(0, 3));
+  }
 
   return {
     reason: parsed.reason || "Tenta ser mais específico e puxar um detalhe da conversa.",

--- a/lib/services/scenario.ts
+++ b/lib/services/scenario.ts
@@ -196,6 +196,8 @@ export async function completeScenario(
     hintsUsed: number;
     hintPenaltyScore: number;
     hintPenaltyXp: number;
+    directHintPenaltyScore?: number;
+    directHintPenaltyXp?: number;
     rawOverallScore: number;
     adjustedOverallScore: number;
   },
@@ -208,8 +210,14 @@ export async function completeScenario(
       score: score ? JSON.parse(JSON.stringify(score)) : undefined,
       xpEarned: xpEarned ?? (success ? 50 : 10),
       hintsUsed: penalty?.hintsUsed,
-      hintPenaltyScore: penalty?.hintPenaltyScore,
-      hintPenaltyXp: penalty?.hintPenaltyXp,
+      hintPenaltyScore:
+        penalty != null
+          ? penalty.hintPenaltyScore + (penalty.directHintPenaltyScore ?? 0)
+          : undefined,
+      hintPenaltyXp:
+        penalty != null
+          ? penalty.hintPenaltyXp + (penalty.directHintPenaltyXp ?? 0)
+          : undefined,
       rawOverallScore: penalty?.rawOverallScore,
       adjustedOverallScore: penalty?.adjustedOverallScore,
     },

--- a/lib/services/scoring.ts
+++ b/lib/services/scoring.ts
@@ -2,12 +2,17 @@ import type { ConversationMode } from "@/lib/types";
 
 export interface HintPenaltyBreakdown {
   hintsUsed: number;
+  directHintUses: number;
   level: number;
   mode: ConversationMode;
   levelMultiplier: number;
   modeMultiplier: number;
   scorePenalty: number;
+  directScorePenalty: number;
+  totalScorePenalty: number;
   xpPenalty: number;
+  directXpPenalty: number;
+  totalXpPenalty: number;
 }
 
 export interface FinalScoreAndXp {
@@ -39,23 +44,34 @@ function clampScore(score: number): number {
 export function computeHintPenalty(
   level: number,
   hintsUsed: number,
+  directHintUses: number,
   mode: ConversationMode,
 ): HintPenaltyBreakdown {
   const safeLevel = Math.max(1, level);
   const safeHints = Math.max(0, hintsUsed);
+  const safeDirectHintUses = Math.max(0, directHintUses);
   const levelMultiplier = 1 + Math.floor((safeLevel - 1) / 5) * 0.15;
   const modeMultiplier = MODE_MULTIPLIER[mode] ?? 1.0;
   const scorePenalty = safeHints * BASE_PENALTY_PER_HINT * levelMultiplier * modeMultiplier;
+  const directScorePenalty = safeDirectHintUses * BASE_PENALTY_PER_HINT * 1.5 * levelMultiplier * modeMultiplier;
+  const totalScorePenalty = scorePenalty + directScorePenalty;
   const xpPenalty = Math.round(scorePenalty * 0.8);
+  const directXpPenalty = Math.round(directScorePenalty * 0.8);
+  const totalXpPenalty = xpPenalty + directXpPenalty;
 
   return {
     hintsUsed: safeHints,
+    directHintUses: safeDirectHintUses,
     level: safeLevel,
     mode,
     levelMultiplier,
     modeMultiplier,
     scorePenalty: Number(scorePenalty.toFixed(2)),
+    directScorePenalty: Number(directScorePenalty.toFixed(2)),
+    totalScorePenalty: Number(totalScorePenalty.toFixed(2)),
     xpPenalty,
+    directXpPenalty,
+    totalXpPenalty,
   };
 }
 
@@ -64,12 +80,13 @@ export function computeFinalScoreAndXp(params: {
   rawXp: number;
   level: number;
   hintsUsed: number;
+  directHintUses: number;
   mode: ConversationMode;
 }): FinalScoreAndXp {
-  const breakdown = computeHintPenalty(params.level, params.hintsUsed, params.mode);
-  const adjustedScore = clampScore(params.rawScore - breakdown.scorePenalty);
+  const breakdown = computeHintPenalty(params.level, params.hintsUsed, params.directHintUses, params.mode);
+  const adjustedScore = clampScore(params.rawScore - breakdown.totalScorePenalty);
   const minFloor = MIN_XP_FLOOR[params.mode] ?? 1;
-  const adjustedXp = Math.max(minFloor, Math.round(params.rawXp - breakdown.xpPenalty));
+  const adjustedXp = Math.max(minFloor, Math.round(params.rawXp - breakdown.totalXpPenalty));
 
   return {
     rawScore: clampScore(params.rawScore),

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -146,8 +146,11 @@ export interface SessionFeedback {
   rawOverallScore?: number;
   adjustedOverallScore?: number;
   hintsUsed?: number;
+  directHintUses?: number;
   hintPenaltyScore?: number;
+  directHintPenaltyScore?: number;
   hintPenaltyXp?: number;
+  directHintPenaltyXp?: number;
   rawXp?: number;
   adjustedXp?: number;
   skills: SkillScores;


### PR DESCRIPTION
## Summary
- add direct hint-copy usage tracking service in `lib/services/hint-usage.ts`
- wire hint/direct usage tracking through chat + stream flows
- apply adaptive penalties in evaluate/scenario completion and surface breakdown in result UI
- update scoring/session types to carry raw vs adjusted score/XP fields

## Test plan
- [x] local file-level lint diagnostics checked
- [ ] full `npm run lint` / `npm run build` with Node >= 18.17 in CI
- [ ] manual validation of hint panel, penalties, and adjusted result screens

Closes #61
Closes #62
Closes #63
Closes #64
Closes #65
Closes #66
Closes #67
Closes #68
Closes #69

Made with [Cursor](https://cursor.com)