### PR TITLE
Add micro exercise data model and migration

### DIFF
--- a/prisma/migrations/20260410_add_micro_exercises/migration.sql
+++ b/prisma/migrations/20260410_add_micro_exercises/migration.sql
@@ -1,0 +1,70 @@
+CREATE TABLE IF NOT EXISTS "MicroExercise" (
+  "id" TEXT NOT NULL,
+  "slug" TEXT NOT NULL,
+  "type" TEXT NOT NULL,
+  "title" TEXT NOT NULL,
+  "prompt" TEXT NOT NULL,
+  "difficulty" TEXT NOT NULL DEFAULT 'normal',
+  "targetSkill" TEXT NOT NULL,
+  "options" JSONB,
+  "answerKey" JSONB NOT NULL,
+  "explanation" TEXT,
+  "tags" TEXT[] DEFAULT ARRAY[]::TEXT[],
+  "order" INTEGER NOT NULL DEFAULT 0,
+  "isActive" BOOLEAN NOT NULL DEFAULT true,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "MicroExercise_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE IF NOT EXISTS "MicroExerciseAttempt" (
+  "id" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "exerciseId" TEXT NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'completed',
+  "userAnswer" JSONB,
+  "isCorrect" BOOLEAN,
+  "rawScore" DOUBLE PRECISION,
+  "adjustedScore" DOUBLE PRECISION,
+  "rawXp" INTEGER NOT NULL DEFAULT 0,
+  "xpEarned" INTEGER NOT NULL DEFAULT 0,
+  "hintsUsed" INTEGER NOT NULL DEFAULT 0,
+  "directHintUses" INTEGER NOT NULL DEFAULT 0,
+  "hintPenaltyScore" DOUBLE PRECISION NOT NULL DEFAULT 0,
+  "hintPenaltyXp" INTEGER NOT NULL DEFAULT 0,
+  "metadata" JSONB,
+  "completedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "MicroExerciseAttempt_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "MicroExercise_slug_key" ON "MicroExercise"("slug");
+CREATE INDEX IF NOT EXISTS "MicroExercise_isActive_order_idx" ON "MicroExercise"("isActive", "order");
+CREATE INDEX IF NOT EXISTS "MicroExercise_type_difficulty_idx" ON "MicroExercise"("type", "difficulty");
+CREATE INDEX IF NOT EXISTS "MicroExercise_targetSkill_difficulty_idx" ON "MicroExercise"("targetSkill", "difficulty");
+
+CREATE INDEX IF NOT EXISTS "MicroExerciseAttempt_userId_createdAt_idx" ON "MicroExerciseAttempt"("userId", "createdAt");
+CREATE INDEX IF NOT EXISTS "MicroExerciseAttempt_userId_exerciseId_idx" ON "MicroExerciseAttempt"("userId", "exerciseId");
+CREATE INDEX IF NOT EXISTS "MicroExerciseAttempt_exerciseId_createdAt_idx" ON "MicroExerciseAttempt"("exerciseId", "createdAt");
+CREATE INDEX IF NOT EXISTS "MicroExerciseAttempt_status_idx" ON "MicroExerciseAttempt"("status");
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'MicroExerciseAttempt_userId_fkey'
+  ) THEN
+    ALTER TABLE "MicroExerciseAttempt"
+      ADD CONSTRAINT "MicroExerciseAttempt_userId_fkey"
+      FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'MicroExerciseAttempt_exerciseId_fkey'
+  ) THEN
+    ALTER TABLE "MicroExerciseAttempt"
+      ADD CONSTRAINT "MicroExerciseAttempt_exerciseId_fkey"
+      FOREIGN KEY ("exerciseId") REFERENCES "MicroExercise"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+  END IF;
+END $$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,7 @@ model User {
   memories          Memory[]
   notifications     Notification[]
   scenarioAttempts  ScenarioAttempt[]
+  microAttempts     MicroExerciseAttempt[]
   skillScore        UserSkillScore?
   progress          UserProgress?
 }
@@ -231,4 +232,53 @@ model UserProgress {
   createdAt          DateTime  @default(now())
   updatedAt          DateTime  @updatedAt
   user               User      @relation(fields: [userId], references: [id])
+}
+
+model MicroExercise {
+  id          String                @id @default(uuid())
+  slug        String                @unique
+  type        String
+  title       String
+  prompt      String
+  difficulty  String                @default("normal")
+  targetSkill String
+  options     Json?
+  answerKey   Json
+  explanation String?
+  tags        String[]              @default([])
+  order       Int                   @default(0)
+  isActive    Boolean               @default(true)
+  createdAt   DateTime              @default(now())
+  attempts    MicroExerciseAttempt[]
+
+  @@index([isActive, order])
+  @@index([type, difficulty])
+  @@index([targetSkill, difficulty])
+}
+
+model MicroExerciseAttempt {
+  id                String        @id @default(uuid())
+  userId            String
+  exerciseId        String
+  status            String        @default("completed")
+  userAnswer        Json?
+  isCorrect         Boolean?
+  rawScore          Float?
+  adjustedScore     Float?
+  rawXp             Int           @default(0)
+  xpEarned          Int           @default(0)
+  hintsUsed         Int           @default(0)
+  directHintUses    Int           @default(0)
+  hintPenaltyScore  Float         @default(0)
+  hintPenaltyXp     Int           @default(0)
+  metadata          Json?
+  completedAt       DateTime?
+  createdAt         DateTime      @default(now())
+  user              User          @relation(fields: [userId], references: [id])
+  exercise          MicroExercise @relation(fields: [exerciseId], references: [id])
+
+  @@index([userId, createdAt])
+  @@index([userId, exerciseId])
+  @@index([exerciseId, createdAt])
+  @@index([status])
 }


### PR DESCRIPTION
## Summary
- add `MicroExercise` model for exercise catalog
- add `MicroExerciseAttempt` model for user attempts and rewards
- add migration with indexes and foreign keys

## Test plan
- [ ] run prisma migrate in target env
- [ ] run type checks after Prisma client generation

Closes #89

Made with [Cursor](https://cursor.com)