### PR TITLE
Implement micro exercise engine and next/submit APIs

### DIFF
--- a/app/api/micro-exercises/next/route.ts
+++ b/app/api/micro-exercises/next/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { getAuthUser } from "@/lib/supabase/server";
+import { getOrCreateUser } from "@/lib/services/auth";
+import { getNextMicroExercise } from "@/lib/services/micro-exercises";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const authUser = await getAuthUser();
+    if (!authUser) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const user = await getOrCreateUser(authUser);
+    const exercise = await getNextMicroExercise(user.id);
+
+    return NextResponse.json({ exercise });
+  } catch (error) {
+    console.error("[api/micro-exercises/next] GET error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/micro-exercises/submit/route.ts
+++ b/app/api/micro-exercises/submit/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAuthUser } from "@/lib/supabase/server";
+import { getOrCreateUser } from "@/lib/services/auth";
+import { submitMicroExercise } from "@/lib/services/micro-exercises";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(req: NextRequest) {
+  try {
+    const authUser = await getAuthUser();
+    if (!authUser) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const user = await getOrCreateUser(authUser);
+    const body = await req.json().catch(() => ({}));
+
+    const exerciseId =
+      typeof body.exerciseId === "string" ? body.exerciseId : "";
+    const answer =
+      body.answer && typeof body.answer === "object"
+        ? (body.answer as Record<string, unknown>)
+        : {};
+    const hintsUsed =
+      typeof body.hintsUsed === "number" ? body.hintsUsed : undefined;
+    const directHintUses =
+      typeof body.directHintUses === "number" ? body.directHintUses : undefined;
+
+    if (!exerciseId) {
+      return NextResponse.json(
+        { error: "exerciseId is required" },
+        { status: 400 },
+      );
+    }
+
+    const result = await submitMicroExercise({
+      userId: user.id,
+      exerciseId,
+      answer,
+      hintsUsed,
+      directHintUses,
+    });
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("[api/micro-exercises/submit] POST error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/lib/data/micro-exercises.ts
+++ b/lib/data/micro-exercises.ts
@@ -1,0 +1,92 @@
+import type { MicroExerciseDifficulty, MicroExerciseType } from "@/lib/types";
+
+export interface MicroExerciseSeed {
+  slug: string;
+  type: MicroExerciseType;
+  title: string;
+  prompt: string;
+  difficulty: MicroExerciseDifficulty;
+  targetSkill: string;
+  options?: Array<{ id: string; text: string }>;
+  answerKey: Record<string, unknown>;
+  explanation: string;
+  tags: string[];
+  order: number;
+}
+
+export const MICRO_EXERCISE_SEEDS: MicroExerciseSeed[] = [
+  {
+    slug: "best-reply-opener-balance",
+    type: "best_reply",
+    title: "Choose the best opener",
+    prompt:
+      "You matched with someone who says: 'Hey, what are you up to this weekend?' Choose the strongest reply.",
+    difficulty: "easy",
+    targetSkill: "conversationalMomentum",
+    options: [
+      { id: "a", text: "Nothing special. You?" },
+      { id: "b", text: "Honestly just recovering from a brutal week. You?" },
+      { id: "c", text: "Probably coffee + a book on Saturday. What about you?" },
+      { id: "d", text: "Why?" },
+    ],
+    answerKey: { correctOptionId: "c" },
+    explanation: "It is specific, warm, and keeps the conversation moving naturally.",
+    tags: ["opening", "momentum"],
+    order: 1,
+  },
+  {
+    slug: "signal-reading-short-reply",
+    type: "signal_reading",
+    title: "Read the signal",
+    prompt:
+      "They reply: 'haha maybe, let's see' after your invite. What is the best interpretation?",
+    difficulty: "normal",
+    targetSkill: "calibration",
+    options: [
+      { id: "a", text: "Strong yes, lock date now." },
+      { id: "b", text: "Soft uncertainty; keep low-pressure and offer options." },
+      { id: "c", text: "Hard rejection; stop replying forever." },
+      { id: "d", text: "They are testing dominance." },
+    ],
+    answerKey: { correctOptionId: "b" },
+    explanation: "This indicates uncertainty, not commitment nor hard rejection.",
+    tags: ["signals", "calibration"],
+    order: 2,
+  },
+  {
+    slug: "rewrite-pushy-message",
+    type: "rewrite_message",
+    title: "Rewrite this message",
+    prompt:
+      "Rewrite into one sentence with better tone: 'You ignored me all day, at least answer properly now.'",
+    difficulty: "normal",
+    targetSkill: "boundaryRespect",
+    answerKey: {
+      minTokens: 6,
+      positiveTokens: ["no", "worries", "when", "free", "chat", "later", "all good"],
+      avoidTokens: ["ignored", "properly", "now"],
+    },
+    explanation: "The best rewrite removes pressure and invites a low-friction reply.",
+    tags: ["recovery", "tone-shift"],
+    order: 3,
+  },
+  {
+    slug: "next-question-curiosity",
+    type: "next_question",
+    title: "Pick the next question",
+    prompt:
+      "They said: 'I just moved cities for work, still figuring things out.' What is the best next question?",
+    difficulty: "easy",
+    targetSkill: "curiosity",
+    options: [
+      { id: "a", text: "How much money are you making there?" },
+      { id: "b", text: "Do you regret moving?" },
+      { id: "c", text: "What has been the best surprise so far in the new city?" },
+      { id: "d", text: "Cool." },
+    ],
+    answerKey: { correctOptionId: "c" },
+    explanation: "Open, positive, and specific curiosity builds conversational depth.",
+    tags: ["curiosity", "follow-up"],
+    order: 4,
+  },
+];

--- a/lib/services/micro-exercises.ts
+++ b/lib/services/micro-exercises.ts
@@ -1,0 +1,221 @@
+import { prisma } from "@/lib/prisma";
+import { MICRO_EXERCISE_SEEDS } from "@/lib/data/micro-exercises";
+import { computeFinalScoreAndXp } from "@/lib/services/scoring";
+import { awardXP } from "@/lib/services/progression";
+
+type MicroExerciseRecord = {
+  id: string;
+  slug: string;
+  type: string;
+  title: string;
+  prompt: string;
+  difficulty: string;
+  targetSkill: string;
+  options: unknown;
+  explanation: string | null;
+};
+
+function normalizeText(input: string): string {
+  return input.toLowerCase().replace(/[^a-z0-9\s]/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function evaluateMcq(answerKey: Record<string, unknown>, userAnswer: Record<string, unknown>) {
+  const expected = typeof answerKey.correctOptionId === "string" ? answerKey.correctOptionId : "";
+  const got = typeof userAnswer.optionId === "string" ? userAnswer.optionId : "";
+  const isCorrect = expected !== "" && got === expected;
+  return { isCorrect, rawScore: isCorrect ? 100 : 35 };
+}
+
+function evaluateRewrite(answerKey: Record<string, unknown>, userAnswer: Record<string, unknown>) {
+  const rawText = typeof userAnswer.text === "string" ? userAnswer.text : "";
+  const text = normalizeText(rawText);
+  const tokens = new Set(text.split(" ").filter(Boolean));
+
+  const positiveTokens = Array.isArray(answerKey.positiveTokens)
+    ? (answerKey.positiveTokens.filter((t): t is string => typeof t === "string").map(normalizeText))
+    : [];
+  const avoidTokens = Array.isArray(answerKey.avoidTokens)
+    ? (answerKey.avoidTokens.filter((t): t is string => typeof t === "string").map(normalizeText))
+    : [];
+  const minTokens = typeof answerKey.minTokens === "number" ? answerKey.minTokens : 6;
+
+  const positiveHits = positiveTokens.filter((token) => tokens.has(token)).length;
+  const avoidHits = avoidTokens.filter((token) => tokens.has(token)).length;
+  const tokenCount = text.split(" ").filter(Boolean).length;
+
+  let rawScore = 50;
+  if (tokenCount >= minTokens) rawScore += 15;
+  rawScore += positiveHits * 12;
+  rawScore -= avoidHits * 14;
+  rawScore = Math.max(0, Math.min(100, rawScore));
+
+  return { isCorrect: rawScore >= 70, rawScore };
+}
+
+function rawXpForDifficulty(difficulty: string): number {
+  if (difficulty === "hard") return 12;
+  if (difficulty === "normal") return 9;
+  return 6;
+}
+
+async function ensureSeededExercises() {
+  const count = await prisma.microExercise.count();
+  if (count > 0) return;
+
+  await prisma.microExercise.createMany({
+    data: MICRO_EXERCISE_SEEDS.map((exercise) => ({
+      slug: exercise.slug,
+      type: exercise.type,
+      title: exercise.title,
+      prompt: exercise.prompt,
+      difficulty: exercise.difficulty,
+      targetSkill: exercise.targetSkill,
+      options: exercise.options ?? null,
+      answerKey: exercise.answerKey,
+      explanation: exercise.explanation,
+      tags: exercise.tags,
+      order: exercise.order,
+      isActive: true,
+    })),
+    skipDuplicates: true,
+  });
+}
+
+export async function getNextMicroExercise(userId: string): Promise<MicroExerciseRecord | null> {
+  await ensureSeededExercises();
+
+  const exercises = await prisma.microExercise.findMany({
+    where: { isActive: true },
+    select: {
+      id: true,
+      slug: true,
+      type: true,
+      title: true,
+      prompt: true,
+      difficulty: true,
+      targetSkill: true,
+      options: true,
+      explanation: true,
+    },
+    orderBy: [{ order: "asc" }, { createdAt: "asc" }],
+  });
+
+  if (!exercises.length) return null;
+
+  const stats = await prisma.microExerciseAttempt.groupBy({
+    by: ["exerciseId"],
+    where: { userId },
+    _count: { id: true },
+  });
+  const countMap = new Map(stats.map((item) => [item.exerciseId, item._count.id]));
+
+  exercises.sort((a, b) => (countMap.get(a.id) ?? 0) - (countMap.get(b.id) ?? 0));
+  return exercises[0] ?? null;
+}
+
+export async function submitMicroExercise(params: {
+  userId: string;
+  exerciseId: string;
+  answer: Record<string, unknown>;
+  hintsUsed?: number;
+  directHintUses?: number;
+}) {
+  const exercise = await prisma.microExercise.findUnique({
+    where: { id: params.exerciseId },
+  });
+  if (!exercise) {
+    throw new Error("Exercise not found");
+  }
+
+  const answerKey =
+    exercise.answerKey && typeof exercise.answerKey === "object"
+      ? (exercise.answerKey as Record<string, unknown>)
+      : {};
+  const evaluator =
+    exercise.type === "rewrite_message" ? evaluateRewrite : evaluateMcq;
+  const evaluation = evaluator(answerKey, params.answer);
+
+  const userProgress = await prisma.userProgress.findUnique({
+    where: { userId: params.userId },
+    select: { level: true },
+  });
+  const level = userProgress?.level ?? 1;
+  const hintsUsed = Math.max(0, params.hintsUsed ?? 0);
+  const directHintUses = Math.max(0, params.directHintUses ?? 0);
+  const rawXp = rawXpForDifficulty(exercise.difficulty);
+
+  const final = computeFinalScoreAndXp({
+    rawScore: evaluation.rawScore,
+    rawXp,
+    level,
+    hintsUsed,
+    directHintUses,
+    mode: "micro",
+  });
+
+  const noHintBonus = hintsUsed === 0 ? 2 : 0;
+  const firstTodayBonus = await hasAttemptToday(params.userId) ? 0 : 3;
+  const totalXp = final.adjustedXp + noHintBonus + firstTodayBonus;
+
+  const attempt = await prisma.microExerciseAttempt.create({
+    data: {
+      userId: params.userId,
+      exerciseId: exercise.id,
+      status: "completed",
+      userAnswer: params.answer,
+      isCorrect: evaluation.isCorrect,
+      rawScore: final.rawScore,
+      adjustedScore: final.adjustedScore,
+      rawXp: final.rawXp,
+      xpEarned: totalXp,
+      hintsUsed,
+      directHintUses,
+      hintPenaltyScore: final.breakdown.totalScorePenalty,
+      hintPenaltyXp: final.breakdown.totalXpPenalty,
+      metadata: {
+        noHintBonus,
+        firstTodayBonus,
+      },
+      completedAt: new Date(),
+    },
+  });
+
+  await awardXP(params.userId, totalXp, "micro_exercise");
+
+  return {
+    attemptId: attempt.id,
+    exercise: {
+      id: exercise.id,
+      type: exercise.type,
+      title: exercise.title,
+      explanation: exercise.explanation,
+    },
+    result: {
+      isCorrect: evaluation.isCorrect,
+      rawScore: final.rawScore,
+      adjustedScore: final.adjustedScore,
+      rawXp: final.rawXp,
+      adjustedXp: final.adjustedXp,
+      finalXpAwarded: totalXp,
+      bonuses: { noHintBonus, firstTodayBonus },
+      penalties: {
+        hintsUsed,
+        directHintUses,
+        scorePenalty: final.breakdown.totalScorePenalty,
+        xpPenalty: final.breakdown.totalXpPenalty,
+      },
+    },
+  };
+}
+
+async function hasAttemptToday(userId: string): Promise<boolean> {
+  const now = new Date();
+  const dayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const count = await prisma.microExerciseAttempt.count({
+    where: {
+      userId,
+      createdAt: { gte: dayStart },
+    },
+  });
+  return count > 0;
+}

--- a/lib/services/scoring.ts
+++ b/lib/services/scoring.ts
@@ -27,12 +27,14 @@ const MODE_MULTIPLIER: Record<ConversationMode, number> = {
   practice: 1.0,
   scenario: 1.1,
   challenge: 1.25,
+  micro: 0.95,
 };
 
 const MIN_XP_FLOOR: Record<ConversationMode, number> = {
   practice: 3,
   scenario: 5,
   challenge: 8,
+  micro: 2,
 };
 
 const BASE_PENALTY_PER_HINT = 2;

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -109,7 +109,9 @@ export interface AgentConfig {
 
 export type ScenarioDifficulty = "easy" | "normal" | "hard" | "expert";
 export type ScenarioCategory = "opening" | "sustain" | "recovery" | "rejection" | "flirting" | "transition";
-export type ConversationMode = "practice" | "scenario" | "challenge";
+export type ConversationMode = "practice" | "scenario" | "challenge" | "micro";
+export type MicroExerciseType = "best_reply" | "signal_reading" | "rewrite_message" | "next_question";
+export type MicroExerciseDifficulty = "easy" | "normal" | "hard";
 
 // --- Skill Evaluation ---
 


### PR DESCRIPTION
## Summary
- add micro exercise seed catalog and service layer
- implement `GET /api/micro-exercises/next`
- implement `POST /api/micro-exercises/submit`
- extend scoring/types to support micro mode penalties and rewards

## Test plan
- [x] read lints for modified files
- [ ] run full build in CI (Node >= 18.17)
- [ ] manually verify next/submit flow with authenticated user

Closes #90

Made with [Cursor](https://cursor.com)