### PR TITLE
Full platform audit & enhancement: resilience, UX, accessibility, content

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,6 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY="eyJ..."
 # OpenAI
 OPENAI_API_KEY="sk-..."
 OPENAI_MODEL="gpt-4o"
+
+# Supabase Admin (for account deletion — from Supabase dashboard > Settings > API > service_role)
+SUPABASE_SERVICE_ROLE_KEY=""

--- a/app/api/chat/hint/route.ts
+++ b/app/api/chat/hint/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { generateContextualHint } from "@/lib/services/hint";
+import { chatHintLimiter } from "@/lib/utils/rate-limit";
 import type { ConversationMode } from "@/lib/types";
 
 const hintSchema = z.object({
@@ -16,6 +17,16 @@ const hintSchema = z.object({
 export async function POST(req: NextRequest) {
   try {
     const body = hintSchema.parse(await req.json());
+
+    // Rate limiting
+    const rateCheck = chatHintLimiter.check(body.userId);
+    if (!rateCheck.allowed) {
+      return NextResponse.json(
+        { error: "Too many hint requests", retryAfterMs: rateCheck.retryAfterMs },
+        { status: 429 },
+      );
+    }
+
     const result = await generateContextualHint({
       userId: body.userId,
       agentId: body.agentId,

--- a/app/api/chat/stream/route.ts
+++ b/app/api/chat/stream/route.ts
@@ -8,10 +8,14 @@ import { retrieveMemories, extractMemories } from "@/lib/services/memory";
 import { updateMood } from "@/lib/services/mood";
 import { checkMilestones } from "@/lib/services/milestone";
 import { trackDirectHintUse } from "@/lib/services/hint-usage";
+import { sanitizeUserMessage } from "@/lib/utils/sanitize";
+import { chatStreamLimiter } from "@/lib/utils/rate-limit";
+import { logger } from "@/lib/utils/logger";
 import { config } from "@/lib/config";
 import { z } from "zod";
 import OpenAI from "openai";
 
+const log = logger("api/chat/stream");
 const openai = new OpenAI({ apiKey: config.openaiApiKey });
 
 const sendMessageSchema = z.object({
@@ -47,7 +51,18 @@ export async function POST(req: NextRequest) {
     return new Response(JSON.stringify({ error: "Invalid request" }), { status: 400 });
   }
 
-  const { userId, agentId, message, mode = "practice", scenarioId } = body;
+  const { userId, agentId, mode = "practice", scenarioId } = body;
+  const message = sanitizeUserMessage(body.message);
+
+  // Rate limiting
+  const rateCheck = chatStreamLimiter.check(userId);
+  if (!rateCheck.allowed) {
+    return new Response(
+      JSON.stringify({ error: "Too many requests", retryAfterMs: rateCheck.retryAfterMs }),
+      { status: 429, headers: { "Retry-After": String(Math.ceil((rateCheck.retryAfterMs || 10000) / 1000)) } },
+    );
+  }
+
   const agent = getAgent(agentId);
   if (!agent) {
     return new Response(JSON.stringify({ error: "Agent not found" }), { status: 404 });
@@ -159,21 +174,24 @@ export async function POST(req: NextRequest) {
         // Background: state + memory + milestones (batched)
         const messageCount = recentMessages.length;
         const allMessages = [...recentMessages.map((m) => ({ senderRole: m.senderRole, content: m.content })), { senderRole: "assistant", content: fullReply }];
+        const bgContext = { userId, agentId, conversationId: conversation.id, messageCount };
 
         const backgroundTasks: Promise<unknown>[] = [
-          // State deltas every 4 messages (was every message)
+          // State deltas every 4 messages
           messageCount % 4 === 0
             ? computeStateDelta(message, fullReply, agent, state)
                 .then((delta) => applyDelta(userId, agentId, delta))
                 .then(() => checkStageProgression(userId, agentId, agent))
+                .catch((err) => { log.error("Background state delta failed", err, bgContext); })
             : Promise.resolve(),
-          // Memory extraction every 10 messages (was every 6)
+          // Memory extraction every 10 messages
           messageCount % 10 === 0
             ? extractMemories(userId, agentId, allMessages, agent)
+                .catch((err) => { log.error("Background memory extraction failed", err, bgContext); return 0; })
             : Promise.resolve(0),
           // Milestones check
           checkMilestones(userId, agentId, previousStage)
-            .catch(() => [] as { type: string; label: string }[]),
+            .catch((err) => { log.error("Background milestone check failed", err, bgContext); return [] as { type: string; label: string }[]; }),
         ];
 
         const results = await Promise.all(backgroundTasks);

--- a/app/api/evaluate/route.ts
+++ b/app/api/evaluate/route.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/services/progression";
 import { getAgent } from "@/lib/agents";
 import { computeFinalScoreAndXp } from "@/lib/services/scoring";
+import { evaluateLimiter } from "@/lib/utils/rate-limit";
 
 const evaluateSchema = z.object({
   conversationId: z.string(),
@@ -30,6 +31,15 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
     const user = await getOrCreateUser(authUser);
+
+    // Rate limiting
+    const rateCheck = evaluateLimiter.check(user.id);
+    if (!rateCheck.allowed) {
+      return NextResponse.json(
+        { error: "Too many evaluation requests", retryAfterMs: rateCheck.retryAfterMs },
+        { status: 429 },
+      );
+    }
 
     const body = await req.json();
     const { conversationId, agentId } = evaluateSchema.parse(body);

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Health check endpoint. Verifies:
+ * - Application is running
+ * - Database is reachable
+ */
+export async function GET() {
+  const checks: Record<string, { status: string; latencyMs?: number }> = {};
+
+  // Database check
+  const dbStart = Date.now();
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    checks.database = { status: "ok", latencyMs: Date.now() - dbStart };
+  } catch {
+    checks.database = { status: "error", latencyMs: Date.now() - dbStart };
+  }
+
+  const allOk = Object.values(checks).every((c) => c.status === "ok");
+
+  return NextResponse.json(
+    {
+      status: allOk ? "healthy" : "degraded",
+      timestamp: new Date().toISOString(),
+      checks,
+    },
+    { status: allOk ? 200 : 503 },
+  );
+}

--- a/app/api/micro-exercises/submit/route.ts
+++ b/app/api/micro-exercises/submit/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getAuthUser } from "@/lib/supabase/server";
 import { getOrCreateUser } from "@/lib/services/auth";
 import { submitMicroExercise } from "@/lib/services/micro-exercises";
+import { microExerciseLimiter } from "@/lib/utils/rate-limit";
 
 export const dynamic = "force-dynamic";
 
@@ -12,6 +13,16 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
     const user = await getOrCreateUser(authUser);
+
+    // Rate limiting
+    const rateCheck = microExerciseLimiter.check(user.id);
+    if (!rateCheck.allowed) {
+      return NextResponse.json(
+        { error: "Too many requests", retryAfterMs: rateCheck.retryAfterMs },
+        { status: 429 },
+      );
+    }
+
     const body = await req.json().catch(() => ({}));
 
     const exerciseId =

--- a/app/api/user/route.ts
+++ b/app/api/user/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { createClient } from "@supabase/supabase-js";
+import { config } from "@/lib/config";
+import { logger } from "@/lib/utils/logger";
+
+const log = logger("api/user");
 
 export async function DELETE(req: NextRequest) {
   const { searchParams } = req.nextUrl;
@@ -43,12 +48,35 @@ export async function DELETE(req: NextRequest) {
     prisma.notification.deleteMany({ where: { userId } }),
   ]);
 
-  // 3. Delete user record
+  // 3. Delete scenario attempts and progress data
+  await Promise.all([
+    prisma.scenarioAttempt.deleteMany({ where: { userId } }),
+    prisma.microExerciseAttempt.deleteMany({ where: { userId } }),
+    prisma.userSkillScore.deleteMany({ where: { userId } }),
+    prisma.userProgress.deleteMany({ where: { userId } }),
+  ]);
+
+  // 4. Delete user record
   await prisma.user.delete({ where: { id: userId } });
 
-  // 4. Delete Supabase auth user
-  // Note: Supabase admin API is needed for this, which requires the service_role key.
-  // For now, we delete the DB record. The auth user will be orphaned but harmless.
+  // 5. Delete Supabase auth user (requires service_role key)
+  if (config.supabaseServiceRoleKey) {
+    try {
+      const supabaseAdmin = createClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        config.supabaseServiceRoleKey,
+        { auth: { autoRefreshToken: false, persistSession: false } },
+      );
+      const { error } = await supabaseAdmin.auth.admin.deleteUser(authUser.id);
+      if (error) {
+        log.error("Failed to delete Supabase auth user", error, { userId, authId: authUser.id });
+      }
+    } catch (err) {
+      log.error("Supabase admin deletion threw", err, { userId, authId: authUser.id });
+    }
+  } else {
+    log.warn("SUPABASE_SERVICE_ROLE_KEY not set — auth user not deleted", { userId, authId: authUser.id });
+  }
 
   return NextResponse.json({ success: true });
 }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,4 +1,16 @@
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `Missing required environment variable: ${name}. ` +
+      `Check your .env file or deployment configuration.`,
+    );
+  }
+  return value;
+}
+
 export const config = {
-  openaiApiKey: process.env.OPENAI_API_KEY || "",
+  openaiApiKey: requireEnv("OPENAI_API_KEY"),
   openaiModel: process.env.OPENAI_MODEL || "gpt-4o",
+  supabaseServiceRoleKey: process.env.SUPABASE_SERVICE_ROLE_KEY || "",
 };

--- a/lib/data/micro-exercises.ts
+++ b/lib/data/micro-exercises.ts
@@ -15,6 +15,7 @@ export interface MicroExerciseSeed {
 }
 
 export const MICRO_EXERCISE_SEEDS: MicroExerciseSeed[] = [
+  // --- Original 4 exercises ---
   {
     slug: "best-reply-opener-balance",
     type: "best_reply",
@@ -88,5 +89,321 @@ export const MICRO_EXERCISE_SEEDS: MicroExerciseSeed[] = [
     explanation: "Open, positive, and specific curiosity builds conversational depth.",
     tags: ["curiosity", "follow-up"],
     order: 4,
+  },
+
+  // --- Confidence exercises ---
+  {
+    slug: "confidence-tone-check",
+    type: "best_reply",
+    title: "Sound confident, not arrogant",
+    prompt:
+      "They ask: 'So what do you do?' Pick the reply that sounds confident without bragging.",
+    difficulty: "easy",
+    targetSkill: "confidence",
+    options: [
+      { id: "a", text: "I'm in tech. Nothing too exciting." },
+      { id: "b", text: "I build software for startups — it keeps me on my toes." },
+      { id: "c", text: "I'm basically a genius engineer at a top company." },
+      { id: "d", text: "Ugh, work stuff, you don't want to hear about it." },
+    ],
+    answerKey: { correctOptionId: "b" },
+    explanation: "Specific, owns it without downplaying or boasting. Shows ease with who you are.",
+    tags: ["confidence", "tone"],
+    order: 5,
+  },
+  {
+    slug: "confidence-handling-tease",
+    type: "best_reply",
+    title: "Handle a playful tease",
+    prompt:
+      "They say: 'You're such a nerd, aren't you?' in a teasing tone. What's the best response?",
+    difficulty: "normal",
+    targetSkill: "confidence",
+    options: [
+      { id: "a", text: "No I'm not! I'm actually really cool." },
+      { id: "b", text: "Guilty. But I'm the fun kind of nerd." },
+      { id: "c", text: "That's kind of rude." },
+      { id: "d", text: "Yeah... sorry about that." },
+    ],
+    answerKey: { correctOptionId: "b" },
+    explanation: "Owning the tease with humor shows confidence. Defensiveness or apologizing signals insecurity.",
+    tags: ["confidence", "humor"],
+    order: 6,
+  },
+
+  // --- Warmth exercises ---
+  {
+    slug: "warmth-after-vulnerability",
+    type: "best_reply",
+    title: "Respond to a vulnerable moment",
+    prompt:
+      "They share: 'I've been feeling a bit overwhelmed lately with everything going on.' Choose the warmest natural response.",
+    difficulty: "normal",
+    targetSkill: "warmth",
+    options: [
+      { id: "a", text: "You should try meditation." },
+      { id: "b", text: "That sounds rough. What's been weighing on you the most?" },
+      { id: "c", text: "Same honestly." },
+      { id: "d", text: "Don't worry, everything will be fine!" },
+    ],
+    answerKey: { correctOptionId: "b" },
+    explanation: "Acknowledges their feeling and invites them to share more. Avoids fixing, minimizing, or making it about yourself.",
+    tags: ["warmth", "emotional-intelligence"],
+    order: 7,
+  },
+  {
+    slug: "warmth-genuine-compliment",
+    type: "rewrite_message",
+    title: "Make a compliment genuine",
+    prompt:
+      "Rewrite into one sentence that feels genuine, not generic: 'You're really beautiful.'",
+    difficulty: "normal",
+    targetSkill: "warmth",
+    answerKey: {
+      minTokens: 5,
+      positiveTokens: ["smile", "way", "how", "when", "something", "about", "love", "energy", "laugh", "eyes", "vibe"],
+      avoidTokens: ["beautiful", "hot", "gorgeous", "stunning", "sexy"],
+    },
+    explanation: "Genuine compliments are specific — they notice something particular rather than making a generic statement about appearance.",
+    tags: ["warmth", "authenticity"],
+    order: 8,
+  },
+
+  // --- Authenticity exercises ---
+  {
+    slug: "authenticity-avoid-scripted",
+    type: "best_reply",
+    title: "Be real, not scripted",
+    prompt:
+      "First message on a dating app. Their profile mentions they love hiking. Pick the most authentic opener.",
+    difficulty: "easy",
+    targetSkill: "authenticity",
+    options: [
+      { id: "a", text: "If you could hike anywhere in the world, where would you go? 🏔️" },
+      { id: "b", text: "Hey! I noticed you're into hiking. What's your favorite trail around here?" },
+      { id: "c", text: "On a scale of 1-10, how much do you love hiking?" },
+      { id: "d", text: "Hey beautiful 😍" },
+    ],
+    answerKey: { correctOptionId: "b" },
+    explanation: "Direct, specific, and sounds like something a real person would say. Avoids template openers and hollow flattery.",
+    tags: ["authenticity", "opening"],
+    order: 9,
+  },
+  {
+    slug: "authenticity-disagree-gracefully",
+    type: "best_reply",
+    title: "Disagree without conflict",
+    prompt:
+      "They say: 'I think traveling alone is overrated.' You love solo travel. What's the best response?",
+    difficulty: "hard",
+    targetSkill: "authenticity",
+    options: [
+      { id: "a", text: "Oh totally, yeah I agree." },
+      { id: "b", text: "Really? I actually love it. There's something about figuring out a new place on your own terms. What puts you off about it?" },
+      { id: "c", text: "That's wrong. Solo travel is amazing." },
+      { id: "d", text: "Hmm interesting." },
+    ],
+    answerKey: { correctOptionId: "b" },
+    explanation: "Respectfully sharing your own view and being curious about theirs is more authentic than agreeing to please or dismissing their opinion.",
+    tags: ["authenticity", "calibration"],
+    order: 10,
+  },
+
+  // --- Emotional Intelligence exercises ---
+  {
+    slug: "ei-mood-shift-detection",
+    type: "signal_reading",
+    title: "Notice the mood shift",
+    prompt:
+      "The conversation was playful, then they reply: 'yeah I guess so.' (shorter, no emoji, no humor). What happened?",
+    difficulty: "normal",
+    targetSkill: "emotionalIntelligence",
+    options: [
+      { id: "a", text: "Nothing, they're just busy. Keep the same energy." },
+      { id: "b", text: "They're losing interest or something shifted. Acknowledge and adjust tone." },
+      { id: "c", text: "They want you to try harder. Double down." },
+      { id: "d", text: "They're playing hard to get." },
+    ],
+    answerKey: { correctOptionId: "b" },
+    explanation: "Sudden shift to short, flat replies signals disengagement. The emotionally intelligent response is to notice and gently adjust, not escalate.",
+    tags: ["emotional-intelligence", "signals"],
+    order: 11,
+  },
+  {
+    slug: "ei-behind-the-words",
+    type: "signal_reading",
+    title: "What are they really saying?",
+    prompt:
+      "After canceling plans, they text: 'It's fine, don't worry about it.' What are they actually communicating?",
+    difficulty: "hard",
+    targetSkill: "emotionalIntelligence",
+    options: [
+      { id: "a", text: "They're totally fine with it. Move on." },
+      { id: "b", text: "They're disappointed but don't want to seem clingy. Acknowledge their feeling." },
+      { id: "c", text: "They're angry and passive-aggressive. Apologize profusely." },
+      { id: "d", text: "They don't care about you." },
+    ],
+    answerKey: { correctOptionId: "b" },
+    explanation: "'It's fine' after a cancellation usually masks disappointment. Acknowledging that shows emotional awareness.",
+    tags: ["emotional-intelligence", "signals"],
+    order: 12,
+  },
+
+  // --- Boundary Respect exercises ---
+  {
+    slug: "boundary-graceful-rejection",
+    type: "best_reply",
+    title: "Accept a boundary gracefully",
+    prompt:
+      "You suggest meeting up, they say: 'I'm not really comfortable meeting yet. Still getting to know you.' Best response?",
+    difficulty: "normal",
+    targetSkill: "boundaryRespect",
+    options: [
+      { id: "a", text: "Come on, it's just coffee. What's the big deal?" },
+      { id: "b", text: "That makes sense. No rush at all — I'm enjoying getting to know you here." },
+      { id: "c", text: "Fine." },
+      { id: "d", text: "Okay but when then? I need to know." },
+    ],
+    answerKey: { correctOptionId: "b" },
+    explanation: "Validates their boundary without pressure, passive-aggression, or demanding a timeline. Shows maturity.",
+    tags: ["boundary-respect", "calibration"],
+    order: 13,
+  },
+  {
+    slug: "boundary-topic-change",
+    type: "signal_reading",
+    title: "Respect the redirect",
+    prompt:
+      "You ask about their ex and they say: 'I'd rather not get into that. Anyway, have you seen any good movies lately?' What should you do?",
+    difficulty: "easy",
+    targetSkill: "boundaryRespect",
+    options: [
+      { id: "a", text: "Follow their lead — talk about movies and come back to deeper topics later." },
+      { id: "b", text: "Push gently: 'I understand, but I think it's important to talk about.'" },
+      { id: "c", text: "Say 'fine' and drop the conversation entirely." },
+      { id: "d", text: "Bring it up again in a different way." },
+    ],
+    answerKey: { correctOptionId: "a" },
+    explanation: "When someone redirects, they're setting a boundary. Following their lead shows respect and builds trust.",
+    tags: ["boundary-respect", "trust"],
+    order: 14,
+  },
+
+  // --- Calibration exercises ---
+  {
+    slug: "calibration-intensity-match",
+    type: "best_reply",
+    title: "Match their energy",
+    prompt:
+      "First few messages. They're keeping it light and casual: 'haha yeah I love pizza too 🍕'. Pick the best-calibrated response.",
+    difficulty: "easy",
+    targetSkill: "calibration",
+    options: [
+      { id: "a", text: "I feel like pizza preferences say a lot about a person. What's your order?" },
+      { id: "b", text: "Pizza is one of the great joys of life. I wrote an essay about it once." },
+      { id: "c", text: "Nice." },
+      { id: "d", text: "I could eat pizza with you every day honestly." },
+    ],
+    answerKey: { correctOptionId: "a" },
+    explanation: "Matches the light energy, adds a playful twist, and keeps the conversation moving. Not too intense, not too flat.",
+    tags: ["calibration", "tone"],
+    order: 15,
+  },
+  {
+    slug: "calibration-serious-moment",
+    type: "best_reply",
+    title: "Read the room — serious moment",
+    prompt:
+      "They share that their pet recently passed away. What's the most calibrated response?",
+    difficulty: "hard",
+    targetSkill: "calibration",
+    options: [
+      { id: "a", text: "Aw that sucks. Anyway, want to do something fun to take your mind off it?" },
+      { id: "b", text: "I'm so sorry. What was their name? Tell me about them." },
+      { id: "c", text: "You'll get over it, it's just a pet." },
+      { id: "d", text: "😢😢😢 That's the worst thing ever I'm so sorry" },
+    ],
+    answerKey: { correctOptionId: "b" },
+    explanation: "Shows genuine care, invites them to share (which is healing), without minimizing or overdramatizing.",
+    tags: ["calibration", "warmth", "emotional-intelligence"],
+    order: 16,
+  },
+
+  // --- Conversational Momentum exercises ---
+  {
+    slug: "momentum-dead-end-recovery",
+    type: "best_reply",
+    title: "Revive a dying conversation",
+    prompt:
+      "The conversation is stalling. Last few messages were short from both sides. What's the best way to re-inject energy?",
+    difficulty: "normal",
+    targetSkill: "conversationalMomentum",
+    options: [
+      { id: "a", text: "So... what else is new?" },
+      { id: "b", text: "Okay random thought — if you could have dinner with anyone alive, who would it be and why?" },
+      { id: "c", text: "You're being kind of quiet." },
+      { id: "d", text: "Hello? Still there?" },
+    ],
+    answerKey: { correctOptionId: "b" },
+    explanation: "A fun, unexpected question re-energizes the conversation. Calling out the silence or being generic makes it worse.",
+    tags: ["momentum", "recovery"],
+    order: 17,
+  },
+  {
+    slug: "momentum-thread-pulling",
+    type: "next_question",
+    title: "Pull the thread",
+    prompt:
+      "They mention: 'I actually used to play in a band in college.' What's the best follow-up?",
+    difficulty: "easy",
+    targetSkill: "conversationalMomentum",
+    options: [
+      { id: "a", text: "Cool. So what do you do now?" },
+      { id: "b", text: "No way — what instrument? Do you still play?" },
+      { id: "c", text: "Oh I don't know much about music." },
+      { id: "d", text: "Were you any good?" },
+    ],
+    answerKey: { correctOptionId: "b" },
+    explanation: "Following up on the interesting detail with genuine curiosity keeps momentum and shows you're listening.",
+    tags: ["momentum", "curiosity"],
+    order: 18,
+  },
+
+  // --- Pressure Level exercises ---
+  {
+    slug: "pressure-avoid-urgency",
+    type: "rewrite_message",
+    title: "Remove the pressure",
+    prompt:
+      "Rewrite into one sentence without pressure: 'When are we finally going to meet? We've been talking for weeks.'",
+    difficulty: "normal",
+    targetSkill: "pressureLevel",
+    answerKey: {
+      minTokens: 5,
+      positiveTokens: ["sometime", "would", "like", "coffee", "open", "love", "whenever", "no rush", "feel", "up for"],
+      avoidTokens: ["finally", "weeks", "when", "why", "yet"],
+    },
+    explanation: "The rewrite should express interest in meeting without guilt-tripping about time. Invitation, not demand.",
+    tags: ["pressure", "tone-shift"],
+    order: 19,
+  },
+  {
+    slug: "pressure-double-text",
+    type: "signal_reading",
+    title: "Should you double-text?",
+    prompt:
+      "You sent a message 3 hours ago and they haven't replied. You want to follow up. What's the right move?",
+    difficulty: "normal",
+    targetSkill: "pressureLevel",
+    options: [
+      { id: "a", text: "Wait. 3 hours is nothing. They have a life." },
+      { id: "b", text: "Send '???' to get their attention." },
+      { id: "c", text: "Send another message about a totally different topic to seem casual." },
+      { id: "d", text: "Send 'Did I say something wrong?'" },
+    ],
+    answerKey: { correctOptionId: "a" },
+    explanation: "3 hours is a normal response time. Double-texting this soon signals neediness. Patience is confidence.",
+    tags: ["pressure", "calibration"],
+    order: 20,
   },
 ];

--- a/lib/services/chat.ts
+++ b/lib/services/chat.ts
@@ -8,6 +8,13 @@ import { retrieveMemories, extractMemories } from "./memory";
 import { updateMood } from "./mood";
 import { ConversationMode, AgentConstraints } from "@/lib/types";
 import { trackDirectHintUse } from "./hint-usage";
+import { sanitizeUserMessage } from "@/lib/utils/sanitize";
+import { logger } from "@/lib/utils/logger";
+
+const log = logger("chat");
+
+/** Number of recent messages to load for context */
+const MESSAGE_CONTEXT_SIZE = 15;
 
 export interface SendMessageParams {
   userId: string;
@@ -27,7 +34,8 @@ export interface SendMessageResult {
 }
 
 export async function sendMessage(params: SendMessageParams): Promise<SendMessageResult> {
-  const { userId, agentId, message, mode = "practice", scenarioId, attemptId } = params;
+  const { userId, agentId, mode = "practice", scenarioId, attemptId } = params;
+  const message = sanitizeUserMessage(params.message);
 
   const agent = getAgent(agentId);
   if (!agent) {
@@ -73,12 +81,12 @@ export async function sendMessage(params: SendMessageParams): Promise<SendMessag
     },
   });
 
-  // 4. Load context: last 15 messages (down from 30) + memories
+  // 4. Load context: recent messages + memories
   const [recentMessagesDesc, memories] = await Promise.all([
     prisma.message.findMany({
       where: { conversationId: conversation.id },
       orderBy: { createdAt: "desc" },
-      take: 15,
+      take: MESSAGE_CONTEXT_SIZE,
     }),
     retrieveMemories(userId, agentId, agent),
   ]);
@@ -129,16 +137,21 @@ export async function sendMessage(params: SendMessageParams): Promise<SendMessag
   const messageCount = recentMessages.length;
   const allMessages = [...recentMessages.map((m) => ({ senderRole: m.senderRole, content: m.content })), { senderRole: "assistant", content: reply }];
 
-  Promise.all([
-    // State deltas every 4 messages (was every message)
-    messageCount % 4 === 0
-      ? computeStateDelta(message, reply, agent, state)
-          .then((delta) => applyDelta(userId, agentId, delta))
-          .then(() => checkStageProgression(userId, agentId, agent))
-      : Promise.resolve(),
-    // Memory extraction every 10 messages (was every 6)
-    messageCount % 10 === 0 ? extractMemories(userId, agentId, allMessages, agent) : Promise.resolve(0),
-  ]).catch((err) => console.error("Background task error:", err));
+  const bgContext = { userId, agentId, conversationId: conversation.id, messageCount };
+
+  // State deltas every 4 messages
+  if (messageCount % 4 === 0) {
+    computeStateDelta(message, reply, agent, state)
+      .then((delta) => applyDelta(userId, agentId, delta))
+      .then(() => checkStageProgression(userId, agentId, agent))
+      .catch((err) => log.error("Background state delta failed", err, bgContext));
+  }
+
+  // Memory extraction every 10 messages
+  if (messageCount % 10 === 0) {
+    extractMemories(userId, agentId, allMessages, agent)
+      .catch((err) => log.error("Background memory extraction failed", err, bgContext));
+  }
 
   // 10. Return response with message count for scenario tracking
   return {

--- a/lib/services/evaluation.ts
+++ b/lib/services/evaluation.ts
@@ -2,6 +2,9 @@ import { prisma } from "@/lib/prisma";
 import { SkillScores, AgentConfig, SuccessCriteria } from "@/lib/types";
 import { generateStructuredOutput } from "./llm";
 import { UserSkillScore } from "@prisma/client";
+import { logger } from "@/lib/utils/logger";
+
+const log = logger("evaluation");
 
 const SKILL_KEYS: (keyof SkillScores)[] = [
   "confidence",
@@ -127,7 +130,7 @@ export async function evaluateSession(
     const raw = await generateStructuredOutput(prompt);
     return parseAndValidateScores(raw);
   } catch (error) {
-    console.error("[evaluation] LLM evaluation failed, using fallback scores:", error);
+    log.warn("LLM evaluation failed, using fallback scores", { messageCount: messages.length, agentId: agent.id });
     return { ...DEFAULT_SCORES };
   }
 }

--- a/lib/services/feedback.ts
+++ b/lib/services/feedback.ts
@@ -2,6 +2,8 @@ import OpenAI from "openai";
 import { config } from "@/lib/config";
 import { prisma } from "@/lib/prisma";
 import { generateStructuredOutput } from "./llm";
+import { withRetry, isTransientError } from "@/lib/utils/retry";
+import { logger } from "@/lib/utils/logger";
 import type {
   SessionFeedback,
   MessageFeedback,
@@ -11,6 +13,7 @@ import type {
   SuccessCriteria,
 } from "@/lib/types";
 
+const log = logger("feedback");
 const openai = new OpenAI({ apiKey: config.openaiApiKey });
 
 // ---------------------------------------------------------------------------
@@ -20,23 +23,28 @@ const openai = new OpenAI({ apiKey: config.openaiApiKey });
 // dedicated call here while keeping the same model and json_object mode.
 // ---------------------------------------------------------------------------
 async function generateDetailedFeedback(prompt: string): Promise<SessionFeedback> {
-  const response = await openai.chat.completions.create({
-    model: "gpt-4o-mini",
-    messages: [
-      {
-        role: "system",
-        content:
-          "You are a JSON-only conversation coach engine. Return ONLY valid JSON, no markdown, no explanation. All text fields that represent feedback visible to the user must be written in Brazilian Portuguese.",
-      },
-      { role: "user", content: prompt },
-    ],
-    temperature: 0.4,
-    max_tokens: 4000,
-    response_format: { type: "json_object" },
-  });
+  return withRetry(
+    async () => {
+      const response = await openai.chat.completions.create({
+        model: "gpt-4o-mini",
+        messages: [
+          {
+            role: "system",
+            content:
+              "You are a JSON-only conversation coach engine. Return ONLY valid JSON, no markdown, no explanation. All text fields that represent feedback visible to the user must be written in Brazilian Portuguese.",
+          },
+          { role: "user", content: prompt },
+        ],
+        temperature: 0.4,
+        max_tokens: 4000,
+        response_format: { type: "json_object" },
+      });
 
-  const content = response.choices[0]?.message?.content || "{}";
-  return JSON.parse(content) as SessionFeedback;
+      const content = response.choices[0]?.message?.content || "{}";
+      return JSON.parse(content) as SessionFeedback;
+    },
+    { maxAttempts: 2, baseDelayMs: 1500, shouldRetry: isTransientError },
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -235,7 +243,7 @@ Retorne SOMENTE um JSON válido com a estrutura:
 
     return feedback;
   } catch (error) {
-    console.error("[feedback] Failed to generate session feedback:", error);
+    log.error("Failed to generate session feedback", error, { agentId: agent.id });
 
     // Return a minimal fallback so the caller always gets a valid structure
     const fallback: SessionFeedback = {
@@ -293,7 +301,7 @@ export async function saveFeedback(
       },
     });
   } catch (error) {
-    console.error("[feedback] Failed to save feedback for attempt", attemptId, error);
+    log.error("Failed to save feedback", error, { attemptId });
     throw error;
   }
 }

--- a/lib/services/hint-usage.ts
+++ b/lib/services/hint-usage.ts
@@ -45,6 +45,9 @@ function readStringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
 }
 
+/** Max hint suggestions to retain per conversation session */
+const MAX_HINT_HISTORY = 40;
+
 export async function appendHintSuggestions(conversationId: string, suggestions: string[]): Promise<void> {
   if (!suggestions.length) return;
   const conversation = await prisma.conversation.findUnique({
@@ -53,7 +56,17 @@ export async function appendHintSuggestions(conversationId: string, suggestions:
   });
   const meta = toSessionMeta(conversation?.sessionMeta);
   const existing = readStringArray(meta.hintSuggestionHistory);
-  const next = [...existing, ...suggestions].slice(-40);
+
+  // Deduplicate: only add suggestions not already present (normalized comparison)
+  const existingNormalized = new Set(existing.map(normalize));
+  const newUnique = suggestions.filter((s) => !existingNormalized.has(normalize(s)));
+
+  // Evict oldest entries first when exceeding limit
+  const combined = [...existing, ...newUnique];
+  const next = combined.length > MAX_HINT_HISTORY
+    ? combined.slice(combined.length - MAX_HINT_HISTORY)
+    : combined;
+
   await prisma.conversation.update({
     where: { id: conversationId },
     data: {

--- a/lib/services/llm.ts
+++ b/lib/services/llm.ts
@@ -1,6 +1,9 @@
 import OpenAI from "openai";
 import { config } from "@/lib/config";
+import { withRetry, isTransientError } from "@/lib/utils/retry";
+import { logger } from "@/lib/utils/logger";
 
+const log = logger("llm");
 const openai = new OpenAI({ apiKey: config.openaiApiKey });
 
 export interface ChatMessage {
@@ -39,33 +42,47 @@ export async function generateChatResponse(params: {
   const model = selectModel(stage);
   const maxTokens = params.maxTokens || selectMaxTokens(stage);
 
-  const response = await openai.chat.completions.create({
-    model,
-    messages: [
-      { role: "system", content: systemPrompt },
-      ...messages,
-    ],
-    temperature,
-    max_tokens: maxTokens,
-    frequency_penalty: 0.7,
-    presence_penalty: 0.5,
-  });
+  return withRetry(
+    async () => {
+      const response = await openai.chat.completions.create({
+        model,
+        messages: [
+          { role: "system", content: systemPrompt },
+          ...messages,
+        ],
+        temperature,
+        max_tokens: maxTokens,
+        frequency_penalty: 0.7,
+        presence_penalty: 0.5,
+      });
 
-  return response.choices[0]?.message?.content || "";
+      const content = response.choices[0]?.message?.content;
+      if (!content) {
+        log.warn("Empty response from OpenAI", { model, stage });
+      }
+      return content || "";
+    },
+    { maxAttempts: 3, baseDelayMs: 1000, shouldRetry: isTransientError },
+  );
 }
 
 export async function generateStructuredOutput(prompt: string): Promise<Record<string, number>> {
-  const response = await openai.chat.completions.create({
-    model: "gpt-4o-mini",
-    messages: [
-      { role: "system", content: "You are a JSON-only analysis engine. Return ONLY valid JSON, no markdown, no explanation." },
-      { role: "user", content: prompt },
-    ],
-    temperature: 0.3,
-    max_tokens: 200,
-    response_format: { type: "json_object" },
-  });
+  return withRetry(
+    async () => {
+      const response = await openai.chat.completions.create({
+        model: "gpt-4o-mini",
+        messages: [
+          { role: "system", content: "You are a JSON-only analysis engine. Return ONLY valid JSON, no markdown, no explanation." },
+          { role: "user", content: prompt },
+        ],
+        temperature: 0.3,
+        max_tokens: 200,
+        response_format: { type: "json_object" },
+      });
 
-  const content = response.choices[0]?.message?.content || "{}";
-  return JSON.parse(content);
+      const content = response.choices[0]?.message?.content || "{}";
+      return JSON.parse(content);
+    },
+    { maxAttempts: 3, baseDelayMs: 1000, shouldRetry: isTransientError },
+  );
 }

--- a/lib/services/memory.ts
+++ b/lib/services/memory.ts
@@ -1,6 +1,9 @@
 import { prisma } from "@/lib/prisma";
 import { AgentConfig } from "@/lib/types";
 import { generateStructuredOutput } from "./llm";
+import { logger } from "@/lib/utils/logger";
+
+const log = logger("memory");
 
 interface MemoryCandidate {
   content: string;
@@ -56,14 +59,8 @@ Return ONLY valid JSON.`;
       if (!mem.content || !VALID_TYPES.includes(mem.type)) continue;
       if ((mem.salience || 0) < 0.5 || (mem.confidence || 0) < 0.6) continue;
 
-      // Check for duplicate content
-      const existing = await prisma.memory.findFirst({
-        where: {
-          userId,
-          agentId,
-          content: { contains: mem.content.substring(0, 30) },
-        },
-      });
+      // Check for duplicate content using normalized token overlap
+      const existing = await findDuplicateMemory(userId, agentId, mem.content);
 
       if (!existing) {
         await prisma.memory.create({
@@ -83,9 +80,61 @@ Return ONLY valid JSON.`;
 
     return stored;
   } catch (err) {
-    console.error("Memory extraction error:", err);
+    log.error("Memory extraction failed", err, { userId, agentId });
     return 0;
   }
+}
+
+/**
+ * Improved duplicate detection: normalize text and check token overlap >= 70%.
+ * Falls back to substring check for very short memories.
+ */
+async function findDuplicateMemory(
+  userId: string,
+  agentId: string,
+  content: string,
+): Promise<{ id: string } | null> {
+  const candidates = await prisma.memory.findMany({
+    where: { userId, agentId },
+    select: { id: true, content: true },
+    orderBy: { createdAt: "desc" },
+    take: 50,
+  });
+
+  const normalizedNew = normalizeForComparison(content);
+  const newTokens = normalizedNew.split(" ").filter(Boolean);
+
+  for (const candidate of candidates) {
+    const normalizedExisting = normalizeForComparison(candidate.content);
+
+    // Exact match after normalization
+    if (normalizedNew === normalizedExisting) return candidate;
+
+    // Token overlap check
+    const existingTokens = normalizedExisting.split(" ").filter(Boolean);
+    if (newTokens.length === 0 || existingTokens.length === 0) continue;
+
+    const existingSet = new Set(existingTokens);
+    let overlap = 0;
+    for (const token of newTokens) {
+      if (existingSet.has(token)) overlap++;
+    }
+
+    const similarity = overlap / Math.max(newTokens.length, existingTokens.length);
+    if (similarity >= 0.7) return candidate;
+  }
+
+  return null;
+}
+
+function normalizeForComparison(text: string): string {
+  return text
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 /**

--- a/lib/services/micro-exercises.ts
+++ b/lib/services/micro-exercises.ts
@@ -165,7 +165,7 @@ export async function submitMicroExercise(params: {
       userId: params.userId,
       exerciseId: exercise.id,
       status: "completed",
-      userAnswer: params.answer,
+      userAnswer: JSON.parse(JSON.stringify(params.answer)),
       isCorrect: evaluation.isCorrect,
       rawScore: final.rawScore,
       adjustedScore: final.adjustedScore,

--- a/lib/services/micro-exercises.ts
+++ b/lib/services/micro-exercises.ts
@@ -70,8 +70,9 @@ async function ensureSeededExercises() {
       prompt: exercise.prompt,
       difficulty: exercise.difficulty,
       targetSkill: exercise.targetSkill,
-      options: exercise.options ?? undefined,
-      answerKey: exercise.answerKey,
+      // Cast needed: Prisma Json? expects InputJsonValue, not the typed array
+      options: (exercise.options as unknown) ?? undefined,
+      answerKey: exercise.answerKey as Record<string, unknown>,
       explanation: exercise.explanation,
       tags: exercise.tags,
       order: exercise.order,

--- a/lib/services/micro-exercises.ts
+++ b/lib/services/micro-exercises.ts
@@ -62,24 +62,26 @@ async function ensureSeededExercises() {
   const count = await prisma.microExercise.count();
   if (count > 0) return;
 
-  await prisma.microExercise.createMany({
-    data: MICRO_EXERCISE_SEEDS.map((exercise) => ({
-      slug: exercise.slug,
-      type: exercise.type,
-      title: exercise.title,
-      prompt: exercise.prompt,
-      difficulty: exercise.difficulty,
-      targetSkill: exercise.targetSkill,
-      // Cast needed: Prisma Json? expects InputJsonValue, not the typed array
-      options: (exercise.options as unknown) ?? undefined,
-      answerKey: exercise.answerKey as Record<string, unknown>,
-      explanation: exercise.explanation,
-      tags: exercise.tags,
-      order: exercise.order,
-      isActive: true,
-    })),
-    skipDuplicates: true,
-  });
+  for (const exercise of MICRO_EXERCISE_SEEDS) {
+    await prisma.microExercise.upsert({
+      where: { slug: exercise.slug },
+      update: {},
+      create: {
+        slug: exercise.slug,
+        type: exercise.type,
+        title: exercise.title,
+        prompt: exercise.prompt,
+        difficulty: exercise.difficulty,
+        targetSkill: exercise.targetSkill,
+        options: exercise.options ? JSON.parse(JSON.stringify(exercise.options)) : undefined,
+        answerKey: JSON.parse(JSON.stringify(exercise.answerKey)),
+        explanation: exercise.explanation,
+        tags: exercise.tags,
+        order: exercise.order,
+        isActive: true,
+      },
+    });
+  }
 }
 
 export async function getNextMicroExercise(userId: string): Promise<MicroExerciseRecord | null> {

--- a/lib/services/micro-exercises.ts
+++ b/lib/services/micro-exercises.ts
@@ -70,7 +70,7 @@ async function ensureSeededExercises() {
       prompt: exercise.prompt,
       difficulty: exercise.difficulty,
       targetSkill: exercise.targetSkill,
-      options: exercise.options ?? null,
+      options: exercise.options ?? undefined,
       answerKey: exercise.answerKey,
       explanation: exercise.explanation,
       tags: exercise.tags,

--- a/lib/services/relationship.ts
+++ b/lib/services/relationship.ts
@@ -1,6 +1,9 @@
 import { prisma } from "@/lib/prisma";
 import { AgentConfig } from "@/lib/types";
 import { generateStructuredOutput } from "./llm";
+import { logger } from "@/lib/utils/logger";
+
+const log = logger("relationship");
 
 export interface StateDelta {
   interest: number;
@@ -60,7 +63,8 @@ Return ONLY valid JSON: {"interest":0,"trust":0,"comfort":0,"tension":0,"respect
       conversationDepth: clampDelta(result.conversationDepth),
       dynamicAlignment: clampDelta(result.dynamicAlignment),
     };
-  } catch {
+  } catch (error) {
+    log.warn("State delta LLM failed, using neutral fallback", { agentId: agent.id, stage: currentState.stage });
     // Fallback: small positive deltas for continued engagement
     return { interest: 1, trust: 1, comfort: 1, tension: 0, respect: 1, attachment: 0, emotionalOpenness: 0, conversationDepth: 1, dynamicAlignment: 0 };
   }

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -204,7 +204,6 @@ export interface SuccessCriteria {
   maxTension?: number;
   minTension?: number;
   noInsistenceAfterRejection?: boolean;
-  customCondition?: string;
 }
 
 // --- Progression ---

--- a/lib/utils/logger.ts
+++ b/lib/utils/logger.ts
@@ -1,0 +1,61 @@
+/**
+ * Structured logger for consistent error/info reporting across services.
+ * Outputs JSON to stdout/stderr for easy parsing in production.
+ */
+
+type LogLevel = "info" | "warn" | "error";
+
+interface LogContext {
+  service: string;
+  action?: string;
+  userId?: string;
+  agentId?: string;
+  conversationId?: string;
+  attemptId?: string;
+  [key: string]: unknown;
+}
+
+function formatEntry(level: LogLevel, message: string, context?: LogContext, error?: unknown) {
+  const entry: Record<string, unknown> = {
+    level,
+    message,
+    timestamp: new Date().toISOString(),
+    ...context,
+  };
+
+  if (error instanceof Error) {
+    entry.error = error.message;
+    entry.stack = error.stack;
+  } else if (error !== undefined) {
+    entry.error = String(error);
+  }
+
+  return entry;
+}
+
+function createLogger(defaultContext: LogContext) {
+  return {
+    info(message: string, extra?: Record<string, unknown>) {
+      const entry = formatEntry("info", message, { ...defaultContext, ...extra });
+      console.log(JSON.stringify(entry));
+    },
+
+    warn(message: string, extra?: Record<string, unknown>) {
+      const entry = formatEntry("warn", message, { ...defaultContext, ...extra });
+      console.warn(JSON.stringify(entry));
+    },
+
+    error(message: string, error?: unknown, extra?: Record<string, unknown>) {
+      const entry = formatEntry("error", message, { ...defaultContext, ...extra }, error);
+      console.error(JSON.stringify(entry));
+    },
+  };
+}
+
+/**
+ * Create a scoped logger for a service.
+ * Usage: const log = logger("chat"); log.error("Failed to send", err, { userId });
+ */
+export function logger(service: string) {
+  return createLogger({ service });
+}

--- a/lib/utils/rate-limit.ts
+++ b/lib/utils/rate-limit.ts
@@ -34,11 +34,11 @@ export function createRateLimiter(name: string, config: RateLimitConfig) {
   const timer = setInterval(() => {
     const now = Date.now();
     const staleThreshold = config.refillIntervalMs * 10;
-    for (const [key, entry] of store) {
+    store.forEach((entry, key) => {
       if (now - entry.lastRefill > staleThreshold) {
         store.delete(key);
       }
-    }
+    });
   }, 5 * 60 * 1000);
   // Allow Node.js process to exit even with this timer running
   if (typeof timer === "object" && "unref" in timer) {

--- a/lib/utils/rate-limit.ts
+++ b/lib/utils/rate-limit.ts
@@ -1,0 +1,100 @@
+/**
+ * In-memory sliding-window rate limiter.
+ * Suitable for serverless/single-instance MVP deployments.
+ * For multi-instance production, replace with Redis-based limiter.
+ */
+
+interface RateLimitEntry {
+  tokens: number;
+  lastRefill: number;
+}
+
+interface RateLimitConfig {
+  /** Max tokens (requests) in the window */
+  maxTokens: number;
+  /** Refill interval in milliseconds */
+  refillIntervalMs: number;
+  /** Tokens added per refill interval */
+  refillRate: number;
+}
+
+const stores = new Map<string, Map<string, RateLimitEntry>>();
+
+/**
+ * Create a rate limiter for a named endpoint.
+ * Returns an object with a `check` method that returns { allowed, retryAfterMs }.
+ */
+export function createRateLimiter(name: string, config: RateLimitConfig) {
+  if (!stores.has(name)) {
+    stores.set(name, new Map());
+  }
+  const store = stores.get(name)!;
+
+  // Periodic cleanup of stale entries (every 5 minutes)
+  const timer = setInterval(() => {
+    const now = Date.now();
+    const staleThreshold = config.refillIntervalMs * 10;
+    for (const [key, entry] of store) {
+      if (now - entry.lastRefill > staleThreshold) {
+        store.delete(key);
+      }
+    }
+  }, 5 * 60 * 1000);
+  // Allow Node.js process to exit even with this timer running
+  if (typeof timer === "object" && "unref" in timer) {
+    (timer as { unref: () => void }).unref();
+  }
+
+  return {
+    check(identifier: string): { allowed: boolean; retryAfterMs?: number } {
+      const now = Date.now();
+      let entry = store.get(identifier);
+
+      if (!entry) {
+        entry = { tokens: config.maxTokens, lastRefill: now };
+        store.set(identifier, entry);
+      }
+
+      // Refill tokens based on elapsed time
+      const elapsed = now - entry.lastRefill;
+      const refills = Math.floor(elapsed / config.refillIntervalMs);
+      if (refills > 0) {
+        entry.tokens = Math.min(config.maxTokens, entry.tokens + refills * config.refillRate);
+        entry.lastRefill = now;
+      }
+
+      if (entry.tokens >= 1) {
+        entry.tokens -= 1;
+        return { allowed: true };
+      }
+
+      const retryAfterMs = config.refillIntervalMs - (now - entry.lastRefill);
+      return { allowed: false, retryAfterMs: Math.max(retryAfterMs, 1000) };
+    },
+  };
+}
+
+// Pre-configured limiters for key endpoints
+export const chatStreamLimiter = createRateLimiter("chat-stream", {
+  maxTokens: 10,
+  refillIntervalMs: 10_000,
+  refillRate: 2,
+});
+
+export const chatHintLimiter = createRateLimiter("chat-hint", {
+  maxTokens: 5,
+  refillIntervalMs: 30_000,
+  refillRate: 2,
+});
+
+export const microExerciseLimiter = createRateLimiter("micro-exercise", {
+  maxTokens: 10,
+  refillIntervalMs: 60_000,
+  refillRate: 5,
+});
+
+export const evaluateLimiter = createRateLimiter("evaluate", {
+  maxTokens: 3,
+  refillIntervalMs: 60_000,
+  refillRate: 1,
+});

--- a/lib/utils/retry.ts
+++ b/lib/utils/retry.ts
@@ -1,0 +1,75 @@
+/**
+ * Generic async retry with exponential backoff.
+ * Use for external service calls (OpenAI, etc.) that may transiently fail.
+ */
+export interface RetryOptions {
+  /** Maximum number of attempts (default: 3) */
+  maxAttempts?: number;
+  /** Initial delay in ms before first retry (default: 1000) */
+  baseDelayMs?: number;
+  /** Multiplier for each subsequent delay (default: 2) */
+  backoffFactor?: number;
+  /** Optional predicate: only retry if this returns true for the error */
+  shouldRetry?: (error: unknown) => boolean;
+}
+
+const DEFAULT_OPTIONS: Required<RetryOptions> = {
+  maxAttempts: 3,
+  baseDelayMs: 1000,
+  backoffFactor: 2,
+  shouldRetry: () => true,
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Returns true for errors that are likely transient (network, rate-limit, server errors).
+ * Use as `shouldRetry` for OpenAI / HTTP calls.
+ */
+export function isTransientError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+
+  const err = error as Record<string, unknown>;
+
+  // OpenAI SDK errors with status codes
+  const status = err.status as number | undefined;
+  if (status !== undefined) {
+    // Retry on rate limit (429), server errors (500, 502, 503), timeout (408)
+    return status === 429 || status === 408 || status >= 500;
+  }
+
+  // Network errors
+  const code = err.code as string | undefined;
+  if (code === "ECONNRESET" || code === "ETIMEDOUT" || code === "ENOTFOUND") {
+    return true;
+  }
+
+  return false;
+}
+
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options?: RetryOptions,
+): Promise<T> {
+  const opts = { ...DEFAULT_OPTIONS, ...options };
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= opts.maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+
+      if (attempt >= opts.maxAttempts || !opts.shouldRetry(error)) {
+        throw error;
+      }
+
+      const delay = opts.baseDelayMs * Math.pow(opts.backoffFactor, attempt - 1);
+      await sleep(delay);
+    }
+  }
+
+  throw lastError;
+}

--- a/lib/utils/sanitize.ts
+++ b/lib/utils/sanitize.ts
@@ -1,0 +1,37 @@
+/**
+ * Input sanitization for user messages before LLM injection.
+ * Mitigates prompt injection by stripping control sequences and
+ * marking user content with clear boundary markers.
+ */
+
+/** Maximum allowed message length in characters */
+const MAX_MESSAGE_LENGTH = 2000;
+
+/**
+ * Strip characters that could be used for prompt injection or confuse the model.
+ * - Removes control characters (except newline and tab)
+ * - Strips XML/HTML-like tags that could mimic system prompt delimiters
+ * - Trims and truncates to max length
+ */
+export function sanitizeUserMessage(message: string): string {
+  let cleaned = message
+    // Remove control characters except \n and \t
+    .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "")
+    // Strip sequences that look like XML system prompt delimiters
+    .replace(/<\/?(?:system|simulator_framework|global_rules|persona_voice|dynamic_state|forbidden|scenario_context|memories|examples|personality_calibration|reactions|texting_style)[^>]*>/gi, "")
+    .trim();
+
+  if (cleaned.length > MAX_MESSAGE_LENGTH) {
+    cleaned = cleaned.slice(0, MAX_MESSAGE_LENGTH);
+  }
+
+  return cleaned;
+}
+
+/**
+ * Wrap user message content with clear boundary markers for the prompt.
+ * This helps the model distinguish user input from system instructions.
+ */
+export function wrapUserContent(content: string): string {
+  return `[USER_MESSAGE_START]\n${content}\n[USER_MESSAGE_END]`;
+}


### PR DESCRIPTION
## Summary

Comprehensive audit and enhancement across three dimensions: technical resilience, product/UX, and accessibility. 10 commits, 40+ files changed, ~2500 lines added.

### Technical Hardening
- **OpenAI retry** with exponential backoff (3 attempts on 429/5xx)
- **API rate limiting** on `/chat/stream`, `/chat/hint`, `/micro-exercises/submit`, `/evaluate`
- **Input sanitization** against prompt injection (strips system-tag mimics)
- **Config validation** — `OPENAI_API_KEY` validated at startup
- **Structured JSON logger** replaces inconsistent `console.error` calls
- **Background task error handling** — individual catch blocks instead of silent fire-and-forget
- **Health check endpoint** (`GET /api/health`) — verifies DB connectivity
- **Complete account deletion** — now removes Supabase auth user via Admin API
- **Improved memory deduplication** — normalized token overlap (70%) replaces 30-char substring

### Product & UX (PM/Designer Audit)
- **Onboarding flow** (`/onboarding`) — 3-step wizard: welcome → interests → choose agent
- **Agent gallery** (`/agents`) — browse all 5 personalities with relationship status
- **Navigation overhaul** — main nav links (Agentes, Cenários, Exercícios, Histórico) + mobile bar
- **Settings page** (`/settings`) — consolidated: appearance, profile, chat, notifications, data
- **Functional light theme** — full CSS overrides for all surfaces, text, borders, agent backgrounds
- **Initiative messages UI** — enable/disable toggle + quiet hours pickers (was DB-only)
- **Streak milestones** — XP bonuses at 3/7/14/30 days (+15/+30/+50/+100 XP)
- **Analysis discoverability** — CTA links added to session cards
- **Exercise celebration** — "Pack diário completo!" state on 5/5 exercises
- **Auth redirect** — new users go to `/onboarding` instead of empty dashboard
- **Milestones tuned** — lower thresholds for earlier triggers, Portuguese labels
- **10 new scenarios** (25 total): date logistics, silence, group dynamics, vulnerability, etc.
- **16 new micro-exercises** (20 total) covering all 10 skill dimensions
- **Language unification** — home, exercises, sessions, settings, milestones → Portuguese

### Accessibility (WCAG 2.1 AA)
- `aria-label` on all icon buttons (Header, ChatWindow, SettingsDrawer, NotificationBell, ConversationReplay)
- `aria-live` regions for typing indicator, milestone notifications, hint panel
- `role=dialog` + `aria-modal` + focus trap + ESC close on SettingsDrawer and reset modal
- `role=tablist` + `aria-selected` on SessionHistory filter tabs
- `focus-visible` ring on all interactive elements
- `prefers-reduced-motion` CSS override disables all animations
- Responsive: `max-w-[calc(100vw-2rem)]` on drawer, `px-4 sm:px-6` on all pages, grid fixes

### Polish
- Hint cooldown timer shows countdown ("3s") instead of just disabling
- Scenario counter: "3 de 10 msgs" instead of ambiguous "3/10"
- Standardized `disabled:opacity-50` across all components
- Empty states with actionable CTAs
- Removed unused `customCondition` from SuccessCriteria type

## Test plan

- [ ] `npm run build` passes
- [ ] Sign up new account → redirected to `/onboarding`
- [ ] Complete onboarding → lands in chat with chosen agent
- [ ] Visit `/agents` → see all 5 personalities with cards
- [ ] Toggle light theme in `/settings` → colors update across app
- [ ] Enable/disable initiative messages in `/settings` → persists
- [ ] Set quiet hours → persists via API
- [ ] Send chat messages → milestones appear after 8-12 quality messages
- [ ] Toggle milestones off → no milestone notifications in chat
- [ ] Complete 5 micro-exercises → celebration state shown
- [ ] `GET /api/health` returns healthy status
- [ ] Rapid-fire chat requests → 429 rate limit response
- [ ] Tab through entire app → all elements have visible focus indicators
- [ ] Enable `prefers-reduced-motion` → all animations disabled
- [ ] Test on 375px mobile width → no horizontal overflow

https://claude.ai/code/session_01F3tcsimH7y7TtUuxhEvzPK