### PR TITLE
Add light theme, settings page, and milestone improvements

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -93,11 +93,18 @@ export default function Header() {
             )}
             <button
               onClick={() => setSettingsOpen(true)}
-              className="rounded-lg p-2 text-base-400 transition-colors hover:bg-base-700/60 hover:text-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mira-500/50"
+              className="rounded-lg p-2 text-base-400 transition-colors hover:bg-base-700/60 hover:text-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mira-500/50 md:hidden"
               aria-label="Definições"
             >
               <Settings size={18} aria-hidden="true" />
             </button>
+            <a
+              href="/settings"
+              className="hidden rounded-lg p-2 text-base-400 transition-colors hover:bg-base-700/60 hover:text-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mira-500/50 md:block"
+              aria-label="Definições"
+            >
+              <Settings size={18} aria-hidden="true" />
+            </a>
           </div>
         </div>
 

--- a/app/components/ThemeProvider.tsx
+++ b/app/components/ThemeProvider.tsx
@@ -19,18 +19,31 @@ export default function ThemeProvider({ children }: { children: React.ReactNode 
 
   useEffect(() => {
     const stored = localStorage.getItem("theme") as Theme | null;
-    if (stored) setTheme(stored);
-    else if (window.matchMedia("(prefers-color-scheme: light)").matches) setTheme("light");
+    if (stored) {
+      setTheme(stored);
+    } else if (window.matchMedia("(prefers-color-scheme: light)").matches) {
+      setTheme("light");
+    } else {
+      setTheme("dark");
+    }
     setMounted(true);
   }, []);
 
   useEffect(() => {
     if (!mounted) return;
-    document.documentElement.classList.toggle("dark", theme === "dark");
+    const root = document.documentElement;
+    if (theme === "dark") {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
     localStorage.setItem("theme", theme);
   }, [theme, mounted]);
 
-  if (!mounted) return <div className="dark">{children}</div>;
+  // SSR: always render dark to prevent flash
+  if (!mounted) {
+    return <div className="dark">{children}</div>;
+  }
 
   return (
     <ThemeContext.Provider value={{ theme, toggleTheme: () => setTheme((p) => (p === "dark" ? "light" : "dark")) }}>

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,11 +3,25 @@
 @tailwind utilities;
 
 @layer base {
+  /* --- Dark mode (default) --- */
+  .dark body,
   body {
     background-color: #06060b;
     color: #c8c8dc;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+  }
+
+  /* --- Light mode overrides --- */
+  :root:not(.dark) body {
+    background-color: #f5f5fa;
+    color: #1a1a2a;
+  }
+
+  :root:not(.dark) {
+    --light-surface-bg: rgba(255, 255, 255, 0.85);
+    --light-surface-border: rgba(0, 0, 0, 0.08);
+    --light-surface-shadow: 0 1px 3px rgba(0,0,0,0.06);
   }
 
   /* Per-agent accent system — set on wrapper via className */
@@ -47,6 +61,13 @@
     --agent-subtle: rgba(249, 115, 22, 0.08);
   }
 
+  /* Light mode agent subtles — slightly stronger for visibility on white */
+  :root:not(.dark) .agent-valeria { --agent-subtle: rgba(232, 48, 90, 0.06); --agent-glow: rgba(232, 48, 90, 0.15); }
+  :root:not(.dark) .agent-luna    { --agent-subtle: rgba(232, 121, 168, 0.06); --agent-glow: rgba(232, 121, 168, 0.12); }
+  :root:not(.dark) .agent-mira    { --agent-subtle: rgba(99, 102, 241, 0.06); --agent-glow: rgba(99, 102, 241, 0.15); }
+  :root:not(.dark) .agent-sable   { --agent-subtle: rgba(147, 51, 234, 0.06); --agent-glow: rgba(147, 51, 234, 0.15); }
+  :root:not(.dark) .agent-kira    { --agent-subtle: rgba(249, 115, 22, 0.06); --agent-glow: rgba(249, 115, 22, 0.12); }
+
   /* Default accent (used on non-agent pages) */
   :root {
     --agent-accent: #818cf8;
@@ -58,7 +79,7 @@
 }
 
 @layer utilities {
-  /* Glass surfaces */
+  /* --- Glass surfaces (dark) --- */
   .surface-1 {
     background: rgba(19, 19, 30, 0.85);
     backdrop-filter: blur(12px);
@@ -81,12 +102,36 @@
     box-shadow: 0 20px 60px rgba(0,0,0,0.7), 0 0 0 1px rgba(255,255,255,0.06);
   }
 
-  /* Per-agent chat backgrounds */
+  /* --- Glass surfaces (light) --- */
+  :root:not(.dark) .surface-1 {
+    background: rgba(255, 255, 255, 0.80);
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+  }
+  :root:not(.dark) .surface-2 {
+    background: rgba(255, 255, 255, 0.90);
+    border: 1px solid rgba(0, 0, 0, 0.10);
+    box-shadow: 0 4px 16px rgba(0,0,0,0.08);
+  }
+  :root:not(.dark) .surface-3 {
+    background: rgba(255, 255, 255, 0.95);
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    box-shadow: 0 8px 32px rgba(0,0,0,0.12);
+  }
+
+  /* Per-agent chat backgrounds — dark */
   .chat-bg-valeria { background: radial-gradient(ellipse 80% 50% at 50% -10%, rgba(232,48,90,0.12) 0%, transparent 60%), #06060b; }
   .chat-bg-luna    { background: radial-gradient(ellipse 80% 50% at 50% -10%, rgba(232,121,168,0.10) 0%, transparent 60%), #06060b; }
   .chat-bg-mira    { background: radial-gradient(ellipse 80% 50% at 50% -10%, rgba(99,102,241,0.13) 0%, transparent 60%), #06060b; }
   .chat-bg-sable   { background: radial-gradient(ellipse 80% 50% at 50% -10%, rgba(147,51,234,0.12) 0%, transparent 60%), #06060b; }
   .chat-bg-kira    { background: radial-gradient(ellipse 80% 50% at 50% -10%, rgba(249,115,22,0.10) 0%, transparent 60%), #06060b; }
+
+  /* Per-agent chat backgrounds — light */
+  :root:not(.dark) .chat-bg-valeria { background: radial-gradient(ellipse 80% 50% at 50% -10%, rgba(232,48,90,0.06) 0%, transparent 60%), #f5f5fa; }
+  :root:not(.dark) .chat-bg-luna    { background: radial-gradient(ellipse 80% 50% at 50% -10%, rgba(232,121,168,0.05) 0%, transparent 60%), #f5f5fa; }
+  :root:not(.dark) .chat-bg-mira    { background: radial-gradient(ellipse 80% 50% at 50% -10%, rgba(99,102,241,0.07) 0%, transparent 60%), #f5f5fa; }
+  :root:not(.dark) .chat-bg-sable   { background: radial-gradient(ellipse 80% 50% at 50% -10%, rgba(147,51,234,0.06) 0%, transparent 60%), #f5f5fa; }
+  :root:not(.dark) .chat-bg-kira    { background: radial-gradient(ellipse 80% 50% at 50% -10%, rgba(249,115,22,0.05) 0%, transparent 60%), #f5f5fa; }
 
   /* Per-agent card hover glow */
   .card-glow-valeria { box-shadow: 0 0 0 1px rgba(232,48,90,0.2), 0 8px 32px rgba(232,48,90,0.12); }
@@ -105,6 +150,60 @@
   .shadow-surface-2 {
     box-shadow: 0 8px 32px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.05);
   }
+  :root:not(.dark) .shadow-surface-2 {
+    box-shadow: 0 4px 16px rgba(0,0,0,0.08);
+  }
+}
+
+/* --- Light mode color overrides for Tailwind classes --- */
+:root:not(.dark) {
+  /* Remap base scale for light mode */
+  /* base-950 (darkest) -> lightest background, base-50 (lightest) -> darkest text */
+}
+
+/* Core background/text overrides */
+:root:not(.dark) .bg-base-950 { background-color: #f5f5fa; }
+:root:not(.dark) .bg-base-950\/80 { background-color: rgba(245, 245, 250, 0.80); }
+:root:not(.dark) .bg-base-950\/60 { background-color: rgba(245, 245, 250, 0.60); }
+:root:not(.dark) .bg-base-900 { background-color: #ededf4; }
+:root:not(.dark) .bg-base-800 { background-color: #e4e4ee; }
+:root:not(.dark) .bg-base-800\/85 { background-color: rgba(228, 228, 238, 0.85); }
+:root:not(.dark) .bg-base-800\/70 { background-color: rgba(228, 228, 238, 0.70); }
+:root:not(.dark) .bg-base-800\/60 { background-color: rgba(228, 228, 238, 0.60); }
+:root:not(.dark) .bg-base-800\/50 { background-color: rgba(228, 228, 238, 0.50); }
+:root:not(.dark) .bg-base-700 { background-color: #d8d8e6; }
+:root:not(.dark) .bg-base-700\/80 { background-color: rgba(216, 216, 230, 0.80); }
+:root:not(.dark) .bg-base-700\/60 { background-color: rgba(216, 216, 230, 0.60); }
+:root:not(.dark) .bg-base-700\/50 { background-color: rgba(216, 216, 230, 0.50); }
+:root:not(.dark) .bg-base-700\/40 { background-color: rgba(216, 216, 230, 0.40); }
+:root:not(.dark) .bg-base-600\/80 { background-color: rgba(200, 200, 218, 0.80); }
+:root:not(.dark) .bg-base-600\/50 { background-color: rgba(200, 200, 218, 0.50); }
+
+/* Text color overrides for light mode */
+:root:not(.dark) .text-base-50 { color: #1a1a2a; }
+:root:not(.dark) .text-base-100 { color: #22223a; }
+:root:not(.dark) .text-base-200 { color: #2e2e4a; }
+:root:not(.dark) .text-base-300 { color: #4a4a6a; }
+:root:not(.dark) .text-base-400 { color: #6b6b8a; }
+:root:not(.dark) .text-base-500 { color: #9a9ab0; }
+
+/* Border overrides for light mode */
+:root:not(.dark) .border-base-500\/30 { border-color: rgba(0, 0, 0, 0.10); }
+:root:not(.dark) .border-base-500\/40 { border-color: rgba(0, 0, 0, 0.10); }
+:root:not(.dark) .border-base-500\/20 { border-color: rgba(0, 0, 0, 0.06); }
+:root:not(.dark) .border-base-600\/40 { border-color: rgba(0, 0, 0, 0.08); }
+:root:not(.dark) .border-base-600\/60 { border-color: rgba(0, 0, 0, 0.10); }
+
+/* Ring overrides for light mode */
+:root:not(.dark) .ring-base-500\/30 { --tw-ring-color: rgba(0, 0, 0, 0.10); }
+
+/* Gradient fades for light mode */
+:root:not(.dark) .from-base-950 { --tw-gradient-from: #f5f5fa; }
+:root:not(.dark) .to-base-300 { --tw-gradient-to: #4a4a6a; }
+
+/* Gradient text in header */
+:root:not(.dark) .bg-gradient-to-r.from-base-50.to-base-300 {
+  background-image: linear-gradient(to right, #1a1a2a, #4a4a6a);
 }
 
 /* Accessibility: respect reduced motion preference */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,8 +25,8 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="pt" className={`dark ${inter.variable} ${playfair.variable}`}>
-      <body className="min-h-screen bg-base-950 font-sans text-base-100">
+    <html lang="pt" className={`${inter.variable} ${playfair.variable}`} suppressHydrationWarning>
+      <body className="min-h-screen bg-base-950 dark:bg-base-950 font-sans text-base-100">
         <ThemeProvider>
           <Header />
           <main>{children}</main>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,379 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { Sun, Moon, Bell, BellOff, Clock, MessageSquare, Trash2, Download, ChevronLeft } from "lucide-react";
+import { createClient } from "@/lib/supabase/client";
+import { useTheme } from "@/app/components/ThemeProvider";
+
+interface UserSettings {
+  userId: string;
+  displayName: string | null;
+  bio: string | null;
+  interests: string[];
+  showMilestones: boolean;
+  enableInitiative: boolean;
+  quietHoursStart: string;
+  quietHoursEnd: string;
+}
+
+export default function SettingsPage() {
+  const router = useRouter();
+  const { theme, toggleTheme } = useTheme();
+
+  const [settings, setSettings] = useState<UserSettings | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  // Profile fields
+  const [displayName, setDisplayName] = useState("");
+  const [bio, setBio] = useState("");
+  const [interests, setInterests] = useState<string[]>([]);
+  const [interestInput, setInterestInput] = useState("");
+
+  // Notification fields
+  const [enableInitiative, setEnableInitiative] = useState(true);
+  const [quietHoursStart, setQuietHoursStart] = useState("23:00");
+  const [quietHoursEnd, setQuietHoursEnd] = useState("08:00");
+
+  // Chat fields
+  const [showMilestones, setShowMilestones] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      const supabase = createClient();
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) { router.push("/login"); return; }
+
+      try {
+        const res = await fetch(`/api/settings?authId=${user.id}`);
+        const data = await res.json();
+        if (data.userId) {
+          setSettings(data);
+          setDisplayName(data.displayName || "");
+          setBio(data.bio || "");
+          setInterests(data.interests || []);
+          setShowMilestones(data.showMilestones);
+          setEnableInitiative(data.enableInitiative);
+          setQuietHoursStart(data.quietHoursStart || "23:00");
+          setQuietHoursEnd(data.quietHoursEnd || "08:00");
+        }
+      } catch { /* ignore */ }
+      setLoading(false);
+    }
+    load();
+  }, [router]);
+
+  async function handleSave() {
+    if (!settings) return;
+    setSaving(true);
+    setSaved(false);
+    try {
+      await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          userId: settings.userId,
+          displayName: displayName.trim() || null,
+          bio: bio.trim() || null,
+          interests,
+          showMilestones,
+          enableInitiative,
+          quietHoursStart,
+          quietHoursEnd,
+        }),
+      });
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch { /* ignore */ }
+    setSaving(false);
+  }
+
+  function addInterest() {
+    const trimmed = interestInput.trim();
+    if (!trimmed || interests.length >= 10 || interests.includes(trimmed)) return;
+    setInterests([...interests, trimmed]);
+    setInterestInput("");
+  }
+
+  function removeInterest(interest: string) {
+    setInterests(interests.filter((i) => i !== interest));
+  }
+
+  async function handleExport() {
+    if (!settings) return;
+    try {
+      const res = await fetch(`/api/history?limit=1000`);
+      const data = await res.json();
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `conversa-history-${new Date().toISOString().slice(0, 10)}.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch { /* ignore */ }
+  }
+
+  if (loading) {
+    return (
+      <div className="relative min-h-[calc(100vh-73px)]">
+        <div className="mx-auto max-w-2xl px-4 py-10 sm:px-6">
+          <div className="space-y-4">
+            <div className="h-8 w-48 animate-pulse rounded-lg bg-base-700/60" />
+            <div className="h-64 animate-pulse rounded-2xl bg-base-700/60" />
+            <div className="h-48 animate-pulse rounded-2xl bg-base-700/60" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative min-h-[calc(100vh-73px)]">
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="absolute left-1/2 top-0 h-[300px] w-[500px] -translate-x-1/2 rounded-full bg-mira-500/[0.05] blur-[120px]" />
+      </div>
+
+      <div className="relative mx-auto max-w-2xl px-4 py-10 sm:px-6">
+        <div className="mb-8 flex items-center gap-3">
+          <a
+            href="/"
+            className="rounded-lg p-1.5 text-base-400 transition-colors hover:bg-base-700/60 hover:text-base-100"
+            aria-label="Voltar ao dashboard"
+          >
+            <ChevronLeft size={20} aria-hidden="true" />
+          </a>
+          <h1 className="font-display text-3xl font-semibold text-base-50">Definições</h1>
+        </div>
+
+        <div className="space-y-6">
+          {/* === Appearance === */}
+          <section className="rounded-2xl border border-base-500/40 bg-base-800/85 p-5 backdrop-blur-md">
+            <h2 className="mb-4 text-xs font-semibold uppercase tracking-widest text-base-400">Aparência</h2>
+            <div className="flex gap-3" role="radiogroup" aria-label="Tema">
+              <button
+                onClick={() => { if (theme === "dark") toggleTheme(); }}
+                role="radio"
+                aria-checked={theme === "light"}
+                className={`flex flex-1 flex-col items-center gap-2 rounded-xl border-2 p-4 text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mira-500/50 ${
+                  theme === "light"
+                    ? "border-mira-500/60 bg-mira-500/10 text-mira-300"
+                    : "border-base-500/40 bg-base-700/50 text-base-400 hover:border-base-400/60"
+                }`}
+              >
+                <Sun size={22} aria-hidden="true" />
+                Claro
+              </button>
+              <button
+                onClick={() => { if (theme === "light") toggleTheme(); }}
+                role="radio"
+                aria-checked={theme === "dark"}
+                className={`flex flex-1 flex-col items-center gap-2 rounded-xl border-2 p-4 text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mira-500/50 ${
+                  theme === "dark"
+                    ? "border-mira-500/60 bg-mira-500/10 text-mira-300"
+                    : "border-base-500/40 bg-base-700/50 text-base-400 hover:border-base-400/60"
+                }`}
+              >
+                <Moon size={22} aria-hidden="true" />
+                Escuro
+              </button>
+            </div>
+          </section>
+
+          {/* === Profile === */}
+          <section className="rounded-2xl border border-base-500/40 bg-base-800/85 p-5 backdrop-blur-md">
+            <h2 className="mb-4 text-xs font-semibold uppercase tracking-widest text-base-400">Perfil</h2>
+            <div className="space-y-4">
+              <div>
+                <label htmlFor="displayName" className="mb-1 block text-sm font-medium text-base-200">
+                  Nome de exibição
+                </label>
+                <input
+                  id="displayName"
+                  type="text"
+                  value={displayName}
+                  onChange={(e) => setDisplayName(e.target.value)}
+                  maxLength={100}
+                  placeholder="Como queres ser chamado"
+                  className="w-full rounded-xl border border-base-500/40 bg-base-700/50 px-4 py-2.5 text-sm text-base-100 placeholder-base-500 outline-none transition-shadow focus:shadow-[0_0_0_3px_rgba(99,102,241,0.2)]"
+                />
+              </div>
+              <div>
+                <label htmlFor="bio" className="mb-1 block text-sm font-medium text-base-200">
+                  Bio
+                </label>
+                <textarea
+                  id="bio"
+                  value={bio}
+                  onChange={(e) => setBio(e.target.value)}
+                  maxLength={500}
+                  rows={3}
+                  placeholder="Fala um pouco sobre ti..."
+                  className="w-full resize-none rounded-xl border border-base-500/40 bg-base-700/50 px-4 py-2.5 text-sm text-base-100 placeholder-base-500 outline-none transition-shadow focus:shadow-[0_0_0_3px_rgba(99,102,241,0.2)]"
+                />
+                <p className="mt-1 text-right text-[10px] text-base-500">{bio.length}/500</p>
+              </div>
+              <div>
+                <label htmlFor="interestInput" className="mb-1 block text-sm font-medium text-base-200">
+                  Interesses <span className="text-base-500">({interests.length}/10)</span>
+                </label>
+                <div className="flex gap-2">
+                  <input
+                    id="interestInput"
+                    type="text"
+                    value={interestInput}
+                    onChange={(e) => setInterestInput(e.target.value)}
+                    onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); addInterest(); } }}
+                    maxLength={50}
+                    placeholder="Adicionar interesse"
+                    className="flex-1 rounded-xl border border-base-500/40 bg-base-700/50 px-4 py-2.5 text-sm text-base-100 placeholder-base-500 outline-none transition-shadow focus:shadow-[0_0_0_3px_rgba(99,102,241,0.2)]"
+                  />
+                  <button
+                    onClick={addInterest}
+                    disabled={!interestInput.trim() || interests.length >= 10}
+                    className="rounded-xl bg-mira-500 px-4 py-2.5 text-sm font-medium text-white transition hover:bg-mira-400 disabled:opacity-50"
+                  >
+                    Adicionar
+                  </button>
+                </div>
+                {interests.length > 0 && (
+                  <div className="mt-2 flex flex-wrap gap-1.5">
+                    {interests.map((interest) => (
+                      <span key={interest} className="flex items-center gap-1 rounded-full bg-base-700/80 px-2.5 py-1 text-xs text-base-200">
+                        {interest}
+                        <button
+                          onClick={() => removeInterest(interest)}
+                          className="ml-0.5 text-base-400 hover:text-rose-400 transition-colors"
+                          aria-label={`Remover ${interest}`}
+                        >
+                          ×
+                        </button>
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          </section>
+
+          {/* === Chat === */}
+          <section className="rounded-2xl border border-base-500/40 bg-base-800/85 p-5 backdrop-blur-md">
+            <h2 className="mb-4 text-xs font-semibold uppercase tracking-widest text-base-400">Chat</h2>
+            <div className="space-y-4">
+              <label className="flex items-start gap-3 cursor-pointer group">
+                <input
+                  type="checkbox"
+                  checked={showMilestones}
+                  onChange={(e) => setShowMilestones(e.target.checked)}
+                  className="mt-0.5 h-5 w-5 rounded border-base-500 bg-base-700 accent-mira-500"
+                />
+                <div>
+                  <p className="text-sm font-medium text-base-100 group-hover:text-base-50 transition-colors">
+                    <MessageSquare size={14} className="mr-1.5 inline" aria-hidden="true" />
+                    Milestones de relação
+                  </p>
+                  <p className="text-xs mt-0.5 text-base-400">
+                    Mostra indicadores narrativos durante o chat (ex: &quot;Ela está a abrir-se&quot;).
+                  </p>
+                </div>
+              </label>
+            </div>
+          </section>
+
+          {/* === Notifications === */}
+          <section className="rounded-2xl border border-base-500/40 bg-base-800/85 p-5 backdrop-blur-md">
+            <h2 className="mb-4 text-xs font-semibold uppercase tracking-widest text-base-400">Notificações</h2>
+            <div className="space-y-5">
+              <label className="flex items-start gap-3 cursor-pointer group">
+                <input
+                  type="checkbox"
+                  checked={enableInitiative}
+                  onChange={(e) => setEnableInitiative(e.target.checked)}
+                  className="mt-0.5 h-5 w-5 rounded border-base-500 bg-base-700 accent-mira-500"
+                />
+                <div>
+                  <p className="text-sm font-medium text-base-100 group-hover:text-base-50 transition-colors">
+                    {enableInitiative
+                      ? <><Bell size={14} className="mr-1.5 inline" aria-hidden="true" />Mensagens proativas ativadas</>
+                      : <><BellOff size={14} className="mr-1.5 inline" aria-hidden="true" />Mensagens proativas desativadas</>
+                    }
+                  </p>
+                  <p className="text-xs mt-0.5 text-base-400">
+                    Os agentes enviam mensagens quando não interages há algum tempo.
+                  </p>
+                </div>
+              </label>
+
+              <div>
+                <p className="mb-2 flex items-center gap-1.5 text-sm font-medium text-base-200">
+                  <Clock size={14} aria-hidden="true" />
+                  Horas de silêncio
+                </p>
+                <p className="mb-3 text-xs text-base-400">
+                  Nenhuma mensagem proativa será enviada neste período.
+                </p>
+                <div className="flex items-center gap-3">
+                  <div className="flex-1">
+                    <label htmlFor="quietStart" className="mb-1 block text-xs text-base-400">Início</label>
+                    <input
+                      id="quietStart"
+                      type="time"
+                      value={quietHoursStart}
+                      onChange={(e) => setQuietHoursStart(e.target.value)}
+                      className="w-full rounded-xl border border-base-500/40 bg-base-700/50 px-3 py-2 text-sm text-base-100 outline-none transition-shadow focus:shadow-[0_0_0_3px_rgba(99,102,241,0.2)]"
+                    />
+                  </div>
+                  <span className="mt-5 text-base-500">—</span>
+                  <div className="flex-1">
+                    <label htmlFor="quietEnd" className="mb-1 block text-xs text-base-400">Fim</label>
+                    <input
+                      id="quietEnd"
+                      type="time"
+                      value={quietHoursEnd}
+                      onChange={(e) => setQuietHoursEnd(e.target.value)}
+                      className="w-full rounded-xl border border-base-500/40 bg-base-700/50 px-3 py-2 text-sm text-base-100 outline-none transition-shadow focus:shadow-[0_0_0_3px_rgba(99,102,241,0.2)]"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          {/* === Data === */}
+          <section className="rounded-2xl border border-base-500/40 bg-base-800/85 p-5 backdrop-blur-md">
+            <h2 className="mb-4 text-xs font-semibold uppercase tracking-widest text-base-400">Dados</h2>
+            <div className="space-y-3">
+              <button
+                onClick={handleExport}
+                className="flex w-full items-center gap-2 rounded-xl bg-base-700/50 px-4 py-3 text-sm font-medium text-base-200 transition-colors hover:bg-base-600/50 hover:text-base-50"
+              >
+                <Download size={16} aria-hidden="true" />
+                Exportar histórico de conversas
+              </button>
+              <a
+                href="/profile"
+                className="flex w-full items-center gap-2 rounded-xl bg-rose-500/10 px-4 py-3 text-sm font-medium text-rose-300 transition-colors hover:bg-rose-500/20"
+              >
+                <Trash2 size={16} aria-hidden="true" />
+                Eliminar conta (zona de perigo)
+              </a>
+            </div>
+          </section>
+
+          {/* Save bar */}
+          <div className="sticky bottom-4 flex justify-end gap-3">
+            <button
+              onClick={handleSave}
+              disabled={saving}
+              className="rounded-xl bg-mira-500 px-6 py-2.5 text-sm font-semibold text-white shadow-lg shadow-mira-500/25 transition-all hover:bg-mira-400 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mira-500/50"
+            >
+              {saving ? "A guardar..." : saved ? "Guardado ✓" : "Guardar definições"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/services/milestone.ts
+++ b/lib/services/milestone.ts
@@ -1,20 +1,23 @@
 import { prisma } from "@/lib/prisma";
 
 const STAGE_NARRATIVES: Record<number, string> = {
-  1: "She seems more curious about you now.",
-  2: "She is clearly engaged — your conversations have depth.",
-  3: "She is invested in you. This feels real.",
-  4: "Something deeper has unlocked between you two.",
+  1: "Ela parece mais curiosa sobre ti agora.",
+  2: "Ela está claramente envolvida — as vossas conversas têm profundidade.",
+  3: "Ela está investida em ti. Isto parece real.",
+  4: "Algo mais profundo desbloqueou entre vocês.",
 };
 
 const MILESTONE_DEFINITIONS: { type: string; check: (state: StateSnapshot) => boolean; label: string }[] = [
-  { type: "first_high_trust", check: (s) => s.trust >= 60, label: "She is starting to trust you." },
-  { type: "first_high_comfort", check: (s) => s.comfort >= 60, label: "She feels comfortable with you." },
-  { type: "first_high_tension", check: (s) => s.tension >= 70, label: "There is real tension between you." },
-  { type: "first_high_respect", check: (s) => s.respect >= 70, label: "She clearly respects you." },
-  { type: "first_attachment", check: (s) => s.attachment >= 50, label: "She is becoming attached." },
-  { type: "first_deep_conversation", check: (s) => s.conversationDepth >= 60, label: "Your conversations go deep." },
-  { type: "first_openness", check: (s) => s.emotionalOpenness >= 50, label: "She is opening up to you." },
+  // First tier — achievable in 8-12 good messages
+  { type: "first_interest", check: (s) => s.trust >= 35 && s.comfort >= 30, label: "Ela parece genuinamente interessada." },
+  { type: "first_high_trust", check: (s) => s.trust >= 50, label: "Ela está a começar a confiar em ti." },
+  { type: "first_high_comfort", check: (s) => s.comfort >= 50, label: "Ela sente-se confortável contigo." },
+  // Second tier — requires sustained quality
+  { type: "first_high_tension", check: (s) => s.tension >= 55, label: "Há tensão real entre vocês." },
+  { type: "first_high_respect", check: (s) => s.respect >= 60, label: "Ela respeita-te claramente." },
+  { type: "first_attachment", check: (s) => s.attachment >= 40, label: "Ela está a criar ligação." },
+  { type: "first_deep_conversation", check: (s) => s.conversationDepth >= 45, label: "As vossas conversas são profundas." },
+  { type: "first_openness", check: (s) => s.emotionalOpenness >= 40, label: "Ela está a abrir-se contigo." },
 ];
 
 interface StateSnapshot {


### PR DESCRIPTION
## Summary

- **Functional light theme** — full CSS overrides for all surfaces, text, borders, agent backgrounds and glows. ThemeProvider manages `.dark` class on document root; layout no longer hardcodes it.
- **Dedicated settings page** (`/settings`) — consolidates all user preferences in one place: appearance (theme toggle), profile (name, bio, interests), chat (milestones on/off), notifications (initiative messages on/off + quiet hours pickers — both were DB-only with no UI until now), and data (export history, delete account link).
- **Milestone improvements** — all labels translated to Portuguese, thresholds lowered for earlier triggers (achievable in 8-12 messages vs 20+), new early milestone "Ela parece genuinamente interessada" at trust≥35 + comfort≥30.
- **Header** — settings gear links to `/settings` on desktop, keeps drawer on mobile.

## Test plan

- [ ] Toggle light theme in `/settings` → colors update across entire app (surfaces, text, borders, chat backgrounds)
- [ ] Toggle back to dark → returns to original dark design
- [ ] Set display name, bio, interests → click "Guardar" → reload page → values persisted
- [ ] Toggle initiative messages off → verify via `GET /api/settings`
- [ ] Set quiet hours (e.g. 22:00–07:00) → verify persisted
- [ ] Click "Exportar histórico" → JSON file downloaded
- [ ] Send 8-12 quality messages in chat → milestone notification appears (e.g. "Ela parece genuinamente interessada")
- [ ] Toggle milestones off in `/settings` → no milestone notifications in chat
- [ ] Desktop: settings gear icon links to `/settings` page
- [ ] Mobile: settings gear opens drawer (existing behavior preserved)

https://claude.ai/code/session_01F3tcsimH7y7TtUuxhEvzPK