### PR TITLE
Fix settings page access and coaching toggle visibility

### DIFF
--- a/app/components/ChatWindow.tsx
+++ b/app/components/ChatWindow.tsx
@@ -276,7 +276,7 @@ export default function ChatWindow({
           <div className="flex items-center gap-1">
             <button
               onClick={() => setCoachingEnabled(!coachingEnabled)}
-              className={`rounded-lg p-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mira-500/50 ${
+              className={`flex items-center gap-1 rounded-lg px-2 py-1.5 text-[10px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mira-500/50 ${
                 coachingEnabled
                   ? "bg-amber-500/15 text-amber-400"
                   : "text-base-400 hover:bg-base-700/60 hover:text-base-200"
@@ -284,7 +284,8 @@ export default function ChatWindow({
               aria-label={coachingEnabled ? "Desativar coaching em tempo real" : "Ativar coaching em tempo real"}
               aria-pressed={coachingEnabled}
             >
-              <GraduationCap size={15} aria-hidden="true" />
+              <GraduationCap size={14} aria-hidden="true" />
+              <span className="hidden sm:inline">{coachingEnabled ? "Coach ON" : "Coach"}</span>
             </button>
             <button
               onClick={() => setShowResetConfirm(true)}

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect } from "react";
 import { usePathname } from "next/navigation";
 import { Settings, LogOut, Users, Target, Dumbbell, Clock } from "lucide-react";
 import { createClient } from "@/lib/supabase/client";
-import SettingsDrawer from "./SettingsDrawer";
 import NotificationBell from "./NotificationBell";
 
 const NAV_LINKS = [
@@ -16,7 +15,6 @@ const NAV_LINKS = [
 
 export default function Header() {
   const pathname = usePathname();
-  const [settingsOpen, setSettingsOpen] = useState(false);
   const [user, setUser] = useState<{ email?: string; id?: string } | null>(null);
   const [dbUserId, setDbUserId] = useState<string | null>(null);
 
@@ -91,16 +89,9 @@ export default function Header() {
                 Entrar
               </a>
             )}
-            <button
-              onClick={() => setSettingsOpen(true)}
-              className="rounded-lg p-2 text-base-400 transition-colors hover:bg-base-700/60 hover:text-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mira-500/50 md:hidden"
-              aria-label="Definições"
-            >
-              <Settings size={18} aria-hidden="true" />
-            </button>
             <a
               href="/settings"
-              className="hidden rounded-lg p-2 text-base-400 transition-colors hover:bg-base-700/60 hover:text-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mira-500/50 md:block"
+              className="rounded-lg p-2 text-base-400 transition-colors hover:bg-base-700/60 hover:text-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mira-500/50"
               aria-label="Definições"
             >
               <Settings size={18} aria-hidden="true" />
@@ -133,7 +124,6 @@ export default function Header() {
           </nav>
         )}
       </header>
-      <SettingsDrawer open={settingsOpen} onClose={() => setSettingsOpen(false)} />
     </>
   );
 }


### PR DESCRIPTION
## Summary

- **Settings icon** now always links to `/settings` page on all devices. Was opening the old SettingsDrawer on mobile which only had the theme toggle — users couldn't access profile, notifications, or quiet hours settings.
- **Coaching toggle** now shows "Coach" text label next to the icon (desktop) and "Coach ON" when active. Was icon-only (🎓) which was invisible/easy to miss in the chat header.

## Test plan

- [ ] Mobile: tap settings gear → navigates to `/settings` page (not drawer)
- [ ] Desktop: click settings gear → navigates to `/settings` page
- [ ] `/settings` shows all sections: Aparência, Perfil, Chat, Notificações, Dados
- [ ] Chat: "Coach" button visible in chat header next to reset/settings
- [ ] Click "Coach" → highlights amber, shows "Coach ON"
- [ ] Send message with Coach ON → coaching badge appears below user message

https://claude.ai/code/session_01F3tcsimH7y7TtUuxhEvzPK